### PR TITLE
Spectator nonproxied player tp/viewing

### DIFF
--- a/src/main/java/com/zenith/cache/data/PlayerCache.java
+++ b/src/main/java/com/zenith/cache/data/PlayerCache.java
@@ -30,10 +30,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
-import java.util.Arrays;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
@@ -238,6 +235,11 @@ public class PlayerCache implements CachedData {
         }
         this.thePlayer.setEntityId(id);
         this.entityCache.add(this.thePlayer);
+        return this;
+    }
+
+    public PlayerCache setUuid(UUID uuid) {
+        this.thePlayer.setUuid(uuid);
         return this;
     }
 }

--- a/src/main/java/com/zenith/cache/data/entity/EntityCache.java
+++ b/src/main/java/com/zenith/cache/data/entity/EntityCache.java
@@ -6,6 +6,7 @@ import com.zenith.cache.CachedData;
 import lombok.NonNull;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
@@ -49,10 +50,20 @@ public class EntityCache implements CachedData {
     }
 
     @SuppressWarnings("unchecked")
-    public <E extends Entity> E get(int id)   {
+    public <E extends Entity> E get(int id) {
         Entity entity = this.cachedEntities.get(id);
         if (entity == null) return null;
         return (E) entity;
+    }
+
+    // todo: this is not particularly efficient but is currently used infrequently.
+    //  if there are higher frequency use cases, consider building a secondary cached map of uuids to entity
+    public <E extends Entity> E get(UUID uuid) {
+        return this.cachedEntities.values().stream()
+            .filter(entity -> entity.getUuid().equals(uuid))
+            .map(entity -> (E) entity)
+            .findFirst()
+            .orElse(null);
     }
 
     public Map<Integer, Entity> getEntities() { return this.cachedEntities;}

--- a/src/main/java/com/zenith/feature/spectator/SpectatorUtils.java
+++ b/src/main/java/com/zenith/feature/spectator/SpectatorUtils.java
@@ -14,12 +14,15 @@ import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.zenith.Proxy;
 import com.zenith.cache.CachedData;
 import com.zenith.cache.DataCache;
+import com.zenith.cache.data.entity.Entity;
 import com.zenith.cache.data.entity.EntityPlayer;
 import com.zenith.feature.spectator.entity.mob.SpectatorEntityEnderDragon;
 import com.zenith.network.server.ServerConnection;
 import com.zenith.util.math.MathHelper;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 import static com.github.steveice10.mc.protocol.data.game.entity.player.GameMode.SPECTATOR;
@@ -50,31 +53,55 @@ public final class SpectatorUtils {
         });
     }
 
-    public static void syncSpectatorPositionToPlayer(final ServerConnection spectConnection) {
-        spectConnection.getSpectatorPlayerCache()
-                .setX(CACHE.getPlayerCache().getX())
-                .setY(CACHE.getPlayerCache().getY() + 3) // spawn above player
-                .setZ(CACHE.getPlayerCache().getZ())
-                .setYaw(CACHE.getPlayerCache().getYaw())
-                .setPitch(CACHE.getPlayerCache().getPitch());
-        spectConnection.setAllowSpectatorServerPlayerPosRotate(true);
-        spectConnection.send(new ClientboundPlayerPositionPacket(
-            spectConnection.getSpectatorPlayerCache().getX(),
-            spectConnection.getSpectatorPlayerCache().getY(),
-            spectConnection.getSpectatorPlayerCache().getZ(),
-            spectConnection.getSpectatorPlayerCache().getYaw(),
-            spectConnection.getSpectatorPlayerCache().getPitch(),
-            12345
-        ));
-        spectConnection.setAllowSpectatorServerPlayerPosRotate(false);
-        updateSpectatorPosition(spectConnection);
-
-        Proxy.getInstance().getActiveConnections().forEach(c -> {
-            if (!c.equals(spectConnection) || spectConnection.isShowSelfEntity()) {
-                c.send(spectConnection.getEntitySpawnPacket());
-                c.send(spectConnection.getEntityMetadataPacket());
+    public static void syncSpectatorPositionToEntity(final ServerConnection spectConnection, UUID target) {
+        if (target != null) {
+            boolean hasUpdatedPos = false;
+            if (CACHE.getProfileCache().getProfile().getId().equals(target)) {
+                spectConnection.getSpectatorPlayerCache()
+                        .setX(CACHE.getPlayerCache().getX())
+                        .setY(CACHE.getPlayerCache().getY() + 1) // spawn above entity
+                        .setZ(CACHE.getPlayerCache().getZ())
+                        .setYaw(CACHE.getPlayerCache().getYaw())
+                        .setPitch(CACHE.getPlayerCache().getPitch());
+                hasUpdatedPos = true;
+            } else {
+                for (Entity entity: CACHE.getEntityCache().getEntities().values()) {
+                    if (entity.getUuid().equals(target)) {
+                        spectConnection.getSpectatorPlayerCache()
+                                .setX(entity.getX())
+                                .setY(entity.getY() + 1) // spawn above entity
+                                .setZ(entity.getZ())
+                                .setYaw(entity.getYaw())
+                                .setPitch(entity.getPitch());
+                        hasUpdatedPos = true;
+                        break;
+                    }
+                }
             }
-        });
+            if (hasUpdatedPos) {
+                spectConnection.setAllowSpectatorServerPlayerPosRotate(true);
+                spectConnection.send(new ClientboundPlayerPositionPacket(
+                        spectConnection.getSpectatorPlayerCache().getX(),
+                        spectConnection.getSpectatorPlayerCache().getY(),
+                        spectConnection.getSpectatorPlayerCache().getZ(),
+                        spectConnection.getSpectatorPlayerCache().getYaw(),
+                        spectConnection.getSpectatorPlayerCache().getPitch(),
+                        12345
+                ));
+                spectConnection.setAllowSpectatorServerPlayerPosRotate(false);
+                updateSpectatorPosition(spectConnection);
+
+                Proxy.getInstance().getActiveConnections().forEach(c -> {
+                    if (!c.equals(spectConnection) || spectConnection.isShowSelfEntity()) {
+                        c.send(spectConnection.getEntitySpawnPacket());
+                        c.send(spectConnection.getEntityMetadataPacket());
+                    }
+                });
+            }
+        }
+    }
+    public static void syncSpectatorPositionToProxiedPlayer(final ServerConnection spectConnection) {
+        syncSpectatorPositionToEntity(spectConnection, CACHE.getProfileCache().getProfile().getId());
     }
 
     private static void sendSpectatorsEquipment() {
@@ -115,7 +142,7 @@ public final class SpectatorUtils {
         spectatorEntityPlayer.setUuid(session.getProfileCache().getProfile().getId());
         spectatorEntityPlayer.setSelfPlayer(true);
         spectatorEntityPlayer.setX(CACHE.getPlayerCache().getX());
-        spectatorEntityPlayer.setY(CACHE.getPlayerCache().getY() + 3); // spawn above player
+        spectatorEntityPlayer.setY(CACHE.getPlayerCache().getY() + 1); // spawn above player
         spectatorEntityPlayer.setZ(CACHE.getPlayerCache().getZ());
         spectatorEntityPlayer.setEntityId(session.getSpectatorSelfEntityId());
         spectatorEntityPlayer.setYaw(CACHE.getPlayerCache().getYaw());
@@ -173,7 +200,7 @@ public final class SpectatorUtils {
         final int playerX = (int) CACHE.getPlayerCache().getX() >> 4;
         final int playerZ = (int) CACHE.getPlayerCache().getZ() >> 4;
         if (Math.abs(spectX - playerX) > (CACHE.getChunkCache().getRenderDistance() / 2 + 1) || Math.abs(spectZ - playerZ) > (CACHE.getChunkCache().getRenderDistance() / 2 + 1)) {
-            SpectatorUtils.syncSpectatorPositionToPlayer(spectConnection);
+            SpectatorUtils.syncSpectatorPositionToProxiedPlayer(spectConnection);
         }
     }
 

--- a/src/main/java/com/zenith/feature/spectator/SpectatorUtils.java
+++ b/src/main/java/com/zenith/feature/spectator/SpectatorUtils.java
@@ -19,9 +19,7 @@ import com.zenith.cache.data.entity.EntityPlayer;
 import com.zenith.feature.spectator.entity.mob.SpectatorEntityEnderDragon;
 import com.zenith.network.server.ServerConnection;
 import com.zenith.util.math.MathHelper;
-
 import java.util.Collection;
-import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 

--- a/src/main/java/com/zenith/feature/spectator/SpectatorUtils.java
+++ b/src/main/java/com/zenith/feature/spectator/SpectatorUtils.java
@@ -51,9 +51,9 @@ public final class SpectatorUtils {
         });
     }
 
-    public static void syncSpectatorPositionToEntity(final ServerConnection spectConnection, UUID target) {
+    public static boolean syncSpectatorPositionToEntity(final ServerConnection spectConnection, UUID target) {
+        boolean hasUpdatedPos = false;
         if (target != null) {
-            boolean hasUpdatedPos = false;
             if (CACHE.getProfileCache().getProfile().getId().equals(target)) {
                 spectConnection.getSpectatorPlayerCache()
                         .setX(CACHE.getPlayerCache().getX())
@@ -97,6 +97,7 @@ public final class SpectatorUtils {
                 });
             }
         }
+        return hasUpdatedPos;
     }
     public static void syncSpectatorPositionToProxiedPlayer(final ServerConnection spectConnection) {
         syncSpectatorPositionToEntity(spectConnection, CACHE.getProfileCache().getProfile().getId());

--- a/src/main/java/com/zenith/network/client/handler/incoming/LoginHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/LoginHandler.java
@@ -21,6 +21,7 @@ public class LoginHandler implements IncomingHandler<ClientboundLoginPacket, Cli
         CACHE.getPlayerCache()
             .setHardcore(packet.isHardcore())
             .setEntityId(packet.getEntityId())
+            .setUuid(CACHE.getProfileCache().getProfile().getId())
             .setLastDeathPos(packet.getLastDeathPos())
             .setPortalCooldown(packet.getPortalCooldown())
             .setMaxPlayers(packet.getMaxPlayers())

--- a/src/main/java/com/zenith/network/client/handler/incoming/level/ForgetLevelChunkHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/level/ForgetLevelChunkHandler.java
@@ -18,7 +18,7 @@ public class ForgetLevelChunkHandler implements AsyncIncomingHandler<Clientbound
             final int spectZ = (int) connection.getSpectatorPlayerCache().getZ() >> 4;
             if ((spectX == packet.getX() || spectX + 1 == packet.getX() || spectX - 1 == packet.getX())
                     && (spectZ == packet.getZ() || spectZ + 1 == packet.getZ() || spectZ - 1 == packet.getZ())) {
-                SpectatorUtils.syncSpectatorPositionToPlayer(connection);
+                SpectatorUtils.syncSpectatorPositionToProxiedPlayer(connection);
             }
         });
         return true;

--- a/src/main/java/com/zenith/network/server/ServerConnection.java
+++ b/src/main/java/com/zenith/network/server/ServerConnection.java
@@ -19,6 +19,7 @@ import com.github.steveice10.packetlib.packet.PacketProtocol;
 import com.zenith.Proxy;
 import com.zenith.cache.data.PlayerCache;
 import com.zenith.cache.data.ServerProfileCache;
+import com.zenith.cache.data.entity.Entity;
 import com.zenith.cache.data.entity.EntityCache;
 import com.zenith.event.proxy.ProxyClientDisconnectedEvent;
 import com.zenith.event.proxy.ProxySpectatorDisconnectedEvent;
@@ -68,7 +69,7 @@ public class ServerConnection implements Session, SessionListener {
     protected boolean allowSpectatorServerPlayerPosRotate = true;
     // allow spectator to set their camera to client
     // need to persist state to allow them in and out of this
-    protected boolean playerCam = false;
+    protected Entity cameraTarget = null;
     protected boolean showSelfEntity = true;
     protected int spectatorEntityId = 2147483647 - ThreadLocalRandom.current().nextInt(1000000);
     protected int spectatorSelfEntityId = spectatorEntityId - 1;
@@ -237,6 +238,10 @@ public class ServerConnection implements Session, SessionListener {
 
     public Optional<Packet> getSoundPacket() {
         return spectatorEntity.getSoundPacket(spectatorPlayerCache);
+    }
+
+    public boolean hasCameraTarget() {
+        return cameraTarget != null;
     }
 
     public void initSpectatorEntity() {

--- a/src/main/java/com/zenith/network/server/handler/player/postoutgoing/LoginPostHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/player/postoutgoing/LoginPostHandler.java
@@ -26,7 +26,7 @@ public class LoginPostHandler implements PostOutgoingHandler<ClientboundLoginPac
         // init any active spectators
         session.getProxy().getActiveConnections().stream()
                 .filter(connection -> !connection.equals(session))
-                .filter(connection -> !connection.isPlayerCam())
+                .filter(connection -> !connection.hasCameraTarget())
                 .forEach(connection -> {
                     session.send(connection.getEntitySpawnPacket());
                     session.send(connection.getEntityMetadataPacket());

--- a/src/main/java/com/zenith/network/server/handler/spectator/incoming/InteractEntitySpectatorHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/spectator/incoming/InteractEntitySpectatorHandler.java
@@ -4,19 +4,24 @@ import com.github.steveice10.mc.protocol.data.game.entity.player.InteractAction;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundSetCameraPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.ClientboundRemoveEntitiesPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.player.ServerboundInteractPacket;
+import com.zenith.cache.data.entity.Entity;
 import com.zenith.network.registry.IncomingHandler;
 import com.zenith.network.server.ServerConnection;
+
+import static com.zenith.Shared.CACHE;
 
 public class InteractEntitySpectatorHandler implements IncomingHandler<ServerboundInteractPacket, ServerConnection> {
     @Override
     public boolean apply(final ServerboundInteractPacket packet, final ServerConnection session) {
-//        if (packet.getEntityId() == CACHE.getPlayerCache().getEntityId() && packet.getAction() == InteractAction.ATTACK) {
         if (packet.getAction() == InteractAction.ATTACK) {
-            session.setPlayerCam(true);
-            session.send(new ClientboundSetCameraPacket(packet.getEntityId()));
-            session.getProxy().getActiveConnections().forEach(connection -> {
-                connection.send(new ClientboundRemoveEntitiesPacket(new int[]{session.getSpectatorEntityId()}));
-            });
+            final Entity entity = CACHE.getEntityCache().get(packet.getEntityId());
+            if (entity != null) {
+                session.setCameraTarget(entity);
+                session.send(new ClientboundSetCameraPacket(packet.getEntityId()));
+                session.getProxy().getActiveConnections().forEach(connection -> {
+                    connection.send(new ClientboundRemoveEntitiesPacket(new int[]{session.getSpectatorEntityId()}));
+                });
+            }
         }
         return false;
     }

--- a/src/main/java/com/zenith/network/server/handler/spectator/incoming/InteractEntitySpectatorHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/spectator/incoming/InteractEntitySpectatorHandler.java
@@ -7,14 +7,13 @@ import com.github.steveice10.mc.protocol.packet.ingame.serverbound.player.Server
 import com.zenith.network.registry.IncomingHandler;
 import com.zenith.network.server.ServerConnection;
 
-import static com.zenith.Shared.CACHE;
-
 public class InteractEntitySpectatorHandler implements IncomingHandler<ServerboundInteractPacket, ServerConnection> {
     @Override
     public boolean apply(final ServerboundInteractPacket packet, final ServerConnection session) {
-        if (packet.getEntityId() == CACHE.getPlayerCache().getEntityId() && packet.getAction() == InteractAction.ATTACK) {
+//        if (packet.getEntityId() == CACHE.getPlayerCache().getEntityId() && packet.getAction() == InteractAction.ATTACK) {
+        if (packet.getAction() == InteractAction.ATTACK) {
             session.setPlayerCam(true);
-            session.send(new ClientboundSetCameraPacket(CACHE.getPlayerCache().getEntityId()));
+            session.send(new ClientboundSetCameraPacket(packet.getEntityId()));
             session.getProxy().getActiveConnections().forEach(connection -> {
                 connection.send(new ClientboundRemoveEntitiesPacket(new int[]{session.getSpectatorEntityId()}));
             });

--- a/src/main/java/com/zenith/network/server/handler/spectator/incoming/PlayerCommandSpectatorHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/spectator/incoming/PlayerCommandSpectatorHandler.java
@@ -3,6 +3,7 @@ package com.zenith.network.server.handler.spectator.incoming;
 import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerState;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundSetCameraPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.player.ServerboundPlayerCommandPacket;
+import com.zenith.cache.data.entity.Entity;
 import com.zenith.feature.spectator.SpectatorUtils;
 import com.zenith.network.registry.IncomingHandler;
 import com.zenith.network.server.ServerConnection;
@@ -11,11 +12,12 @@ public class PlayerCommandSpectatorHandler implements IncomingHandler<Serverboun
 
     @Override
     public boolean apply(ServerboundPlayerCommandPacket packet, ServerConnection session) {
-        if (session.isPlayerCam()) {
+        Entity cameraTarget = session.getCameraTarget();
+        if (cameraTarget != null) {
             if (packet.getState() == PlayerState.START_SNEAKING) {
-                session.setPlayerCam(false);
+                session.setCameraTarget(null);
                 session.send(new ClientboundSetCameraPacket(session.getSpectatorSelfEntityId()));
-                SpectatorUtils.syncSpectatorPositionToProxiedPlayer(session);
+                SpectatorUtils.syncSpectatorPositionToEntity(session, cameraTarget);
             }
         } else {
             if (packet.getState() == PlayerState.START_SNEAKING || packet.getState() == PlayerState.START_SPRINTING) {

--- a/src/main/java/com/zenith/network/server/handler/spectator/incoming/PlayerCommandSpectatorHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/spectator/incoming/PlayerCommandSpectatorHandler.java
@@ -15,7 +15,7 @@ public class PlayerCommandSpectatorHandler implements IncomingHandler<Serverboun
             if (packet.getState() == PlayerState.START_SNEAKING) {
                 session.setPlayerCam(false);
                 session.send(new ClientboundSetCameraPacket(session.getSpectatorSelfEntityId()));
-                SpectatorUtils.syncSpectatorPositionToPlayer(session);
+                SpectatorUtils.syncSpectatorPositionToProxiedPlayer(session);
             }
         } else {
             if (packet.getState() == PlayerState.START_SNEAKING || packet.getState() == PlayerState.START_SPRINTING) {

--- a/src/main/java/com/zenith/network/server/handler/spectator/incoming/ServerChatSpectatorHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/spectator/incoming/ServerChatSpectatorHandler.java
@@ -70,7 +70,7 @@ public class ServerChatSpectatorHandler implements IncomingHandler<ServerboundCh
                 });
             } else {
                 session.send(new ClientboundSetCameraPacket(session.getSpectatorSelfEntityId()));
-                SpectatorUtils.syncSpectatorPositionToPlayer(session);
+                SpectatorUtils.syncSpectatorPositionToProxiedPlayer(session);
             }
         } else if (packet.getMessage().toLowerCase().startsWith("!cleareffects")) {
             CACHE.getPlayerCache().getThePlayer().getPotionEffectMap().clear();

--- a/src/main/java/com/zenith/network/server/handler/spectator/incoming/TeleportToEntitySpectatorHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/spectator/incoming/TeleportToEntitySpectatorHandler.java
@@ -1,13 +1,25 @@
 package com.zenith.network.server.handler.spectator.incoming;
 
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundSetCameraPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.level.ServerboundTeleportToEntityPacket;
+import com.zenith.cache.data.entity.Entity;
 import com.zenith.feature.spectator.SpectatorUtils;
 import com.zenith.network.registry.IncomingHandler;
 import com.zenith.network.server.ServerConnection;
 
+import static com.zenith.Shared.CACHE;
+
 public class TeleportToEntitySpectatorHandler implements IncomingHandler<ServerboundTeleportToEntityPacket, ServerConnection> {
     @Override
     public boolean apply(final ServerboundTeleportToEntityPacket packet, final ServerConnection session) {
-        return SpectatorUtils.syncSpectatorPositionToEntity(session, packet.getTarget());
+        final Entity targetEntity = CACHE.getEntityCache().get(packet.getTarget());
+        if (targetEntity != null) {
+            if (session.hasCameraTarget()) {
+                session.setCameraTarget(null);
+                session.send(new ClientboundSetCameraPacket(session.getSpectatorSelfEntityId()));
+            }
+            SpectatorUtils.syncSpectatorPositionToEntity(session, targetEntity);
+        }
+        return false;
     }
 }

--- a/src/main/java/com/zenith/network/server/handler/spectator/incoming/TeleportToEntitySpectatorHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/spectator/incoming/TeleportToEntitySpectatorHandler.java
@@ -5,14 +5,10 @@ import com.zenith.feature.spectator.SpectatorUtils;
 import com.zenith.network.registry.IncomingHandler;
 import com.zenith.network.server.ServerConnection;
 
-import static com.zenith.Shared.CACHE;
-
 public class TeleportToEntitySpectatorHandler implements IncomingHandler<ServerboundTeleportToEntityPacket, ServerConnection> {
     @Override
     public boolean apply(final ServerboundTeleportToEntityPacket packet, final ServerConnection session) {
-        if (CACHE.getProfileCache().getProfile().getId().equals(packet.getTarget())) {
-            SpectatorUtils.syncSpectatorPositionToPlayer(session);
-        }
+        SpectatorUtils.syncSpectatorPositionToEntity(session, packet.getTarget());
         return false;
     }
 }

--- a/src/main/java/com/zenith/network/server/handler/spectator/incoming/TeleportToEntitySpectatorHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/spectator/incoming/TeleportToEntitySpectatorHandler.java
@@ -8,7 +8,6 @@ import com.zenith.network.server.ServerConnection;
 public class TeleportToEntitySpectatorHandler implements IncomingHandler<ServerboundTeleportToEntityPacket, ServerConnection> {
     @Override
     public boolean apply(final ServerboundTeleportToEntityPacket packet, final ServerConnection session) {
-        SpectatorUtils.syncSpectatorPositionToEntity(session, packet.getTarget());
-        return false;
+        return SpectatorUtils.syncSpectatorPositionToEntity(session, packet.getTarget());
     }
 }


### PR DESCRIPTION
allowed teleporation to any valid UUID from spectator mode. Have yet to fix teleport menu to show only nearby players.
allowed viewing of any entity, rather than just proxied player.
TP spectator 1 block above instead of 3

renamed syncSpectatorPositionToPlayer to syncSpectatorPositionToProxiedPlayer
moved logic from syncSpectatorPositionToPlayer to new syncSpectatorPositionToEntity