### PR TITLE
stop chat messages pinging discord id's

### DIFF
--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -392,7 +392,7 @@ public class DiscordBot {
     }
 
     public static String escape(String message) {
-        return message.replaceAll("_", "\\\\_");
+        return message.replaceAll("_", "\\\\_").replaceAll("@", "\\\\@");
     }
 
     public boolean isMessageQueueEmpty() {


### PR DESCRIPTION
Escapes '@' symbols to prevent mass pinging of a user, role, or @‌everyone through server chat messages.