### PR TITLE
Implement scoreboard and team caching

### DIFF
--- a/src/main/java/com/zenith/Shared.java
+++ b/src/main/java/com/zenith/Shared.java
@@ -13,7 +13,10 @@ import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.spawn.
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.inventory.*;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.*;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.border.ClientboundInitializeBorderPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetDisplayObjectivePacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetObjectivePacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetPlayerTeamPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetScorePacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.title.ClientboundSetActionBarTextPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.title.ClientboundSetSubtitleTextPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.*;
@@ -47,6 +50,10 @@ import com.zenith.network.client.handler.incoming.*;
 import com.zenith.network.client.handler.incoming.entity.*;
 import com.zenith.network.client.handler.incoming.inventory.*;
 import com.zenith.network.client.handler.incoming.level.*;
+import com.zenith.network.client.handler.incoming.scoreboard.SetDisplayObjectiveHandler;
+import com.zenith.network.client.handler.incoming.scoreboard.SetObjectiveHandler;
+import com.zenith.network.client.handler.incoming.scoreboard.SetScoreHandler;
+import com.zenith.network.client.handler.incoming.scoreboard.TeamHandler;
 import com.zenith.network.client.handler.incoming.spawn.AddEntityHandler;
 import com.zenith.network.client.handler.incoming.spawn.AddExperienceOrbHandler;
 import com.zenith.network.client.handler.incoming.spawn.AddPlayerHandler;
@@ -267,6 +274,9 @@ public class Shared {
         .registerInbound(ClientboundCustomPayloadPacket.class, new CustomPayloadHandler())
         .registerInbound(ClientboundRecipePacket.class, new UnlockRecipeHandler())
         .registerInbound(ClientboundSetPlayerTeamPacket.class, new TeamHandler())
+        .registerInbound(ClientboundSetObjectivePacket.class, new SetObjectiveHandler())
+        .registerInbound(ClientboundSetDisplayObjectivePacket.class, new SetDisplayObjectiveHandler())
+        .registerInbound(ClientboundSetScorePacket.class, new SetScoreHandler())
         //ENTITY
         .registerInbound(ClientboundEntityEventPacket.class, new EntityEventHandler())
         .registerInbound(ClientboundSetEntityLinkPacket.class, new SetEntityLinkHandler())

--- a/src/main/java/com/zenith/Shared.java
+++ b/src/main/java/com/zenith/Shared.java
@@ -13,6 +13,7 @@ import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.spawn.
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.inventory.*;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.*;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.border.ClientboundInitializeBorderPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetPlayerTeamPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.title.ClientboundSetActionBarTextPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.title.ClientboundSetSubtitleTextPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.*;
@@ -265,6 +266,7 @@ public class Shared {
         .registerInbound(ClientboundPlayerAbilitiesPacket.class, new PlayerAbilitiesHandler())
         .registerInbound(ClientboundCustomPayloadPacket.class, new CustomPayloadHandler())
         .registerInbound(ClientboundRecipePacket.class, new UnlockRecipeHandler())
+        .registerInbound(ClientboundSetPlayerTeamPacket.class, new TeamHandler())
         //ENTITY
         .registerInbound(ClientboundEntityEventPacket.class, new EntityEventHandler())
         .registerInbound(ClientboundSetEntityLinkPacket.class, new SetEntityLinkHandler())

--- a/src/main/java/com/zenith/cache/DataCache.java
+++ b/src/main/java/com/zenith/cache/DataCache.java
@@ -10,6 +10,7 @@ import com.zenith.cache.data.map.MapDataCache;
 import com.zenith.cache.data.recipe.RecipeCache;
 import com.zenith.cache.data.stats.StatisticsCache;
 import com.zenith.cache.data.tab.TabListCache;
+import com.zenith.cache.data.team.TeamCache;
 import com.zenith.network.server.ServerConnection;
 import lombok.Getter;
 
@@ -31,15 +32,16 @@ public class DataCache {
     protected final StatisticsCache statsCache = new StatisticsCache();
     protected final MapDataCache mapDataCache = new MapDataCache();
     protected final RecipeCache recipeCache = new RecipeCache();
+    protected final TeamCache teamCache = new TeamCache();
 
     public Collection<CachedData> getAllData() {
-        return Arrays.asList(profileCache, playerCache, chunkCache, statsCache, tabListCache, bossBarCache, entityCache, chatCache, mapDataCache, recipeCache);
+        return Arrays.asList(profileCache, playerCache, chunkCache, statsCache, tabListCache, bossBarCache, entityCache, chatCache, mapDataCache, recipeCache, teamCache);
     }
 
     // get a limited selection of cache data
     // mainly we don't want to not send the proxy client's player cache
     public Collection<CachedData> getAllDataSpectator(final PlayerCache spectatorPlayerCache) {
-        return Arrays.asList(spectatorPlayerCache, chunkCache, tabListCache, bossBarCache, entityCache, chatCache, mapDataCache, recipeCache);
+        return Arrays.asList(spectatorPlayerCache, chunkCache, tabListCache, bossBarCache, entityCache, chatCache, mapDataCache, recipeCache, teamCache);
     }
 
     public boolean reset(boolean full) {

--- a/src/main/java/com/zenith/cache/DataCache.java
+++ b/src/main/java/com/zenith/cache/DataCache.java
@@ -8,6 +8,7 @@ import com.zenith.cache.data.chunk.ChunkCache;
 import com.zenith.cache.data.entity.EntityCache;
 import com.zenith.cache.data.map.MapDataCache;
 import com.zenith.cache.data.recipe.RecipeCache;
+import com.zenith.cache.data.scoreboard.ScoreboardCache;
 import com.zenith.cache.data.stats.StatisticsCache;
 import com.zenith.cache.data.tab.TabListCache;
 import com.zenith.cache.data.team.TeamCache;
@@ -33,15 +34,16 @@ public class DataCache {
     protected final MapDataCache mapDataCache = new MapDataCache();
     protected final RecipeCache recipeCache = new RecipeCache();
     protected final TeamCache teamCache = new TeamCache();
+    protected final ScoreboardCache scoreboardCache = new ScoreboardCache();
 
     public Collection<CachedData> getAllData() {
-        return Arrays.asList(profileCache, playerCache, chunkCache, statsCache, tabListCache, bossBarCache, entityCache, chatCache, mapDataCache, recipeCache, teamCache);
+        return Arrays.asList(profileCache, playerCache, chunkCache, statsCache, tabListCache, bossBarCache, entityCache, chatCache, mapDataCache, recipeCache, teamCache, scoreboardCache);
     }
 
     // get a limited selection of cache data
     // mainly we don't want to not send the proxy client's player cache
     public Collection<CachedData> getAllDataSpectator(final PlayerCache spectatorPlayerCache) {
-        return Arrays.asList(spectatorPlayerCache, chunkCache, tabListCache, bossBarCache, entityCache, chatCache, mapDataCache, recipeCache, teamCache);
+        return Arrays.asList(spectatorPlayerCache, chunkCache, tabListCache, bossBarCache, entityCache, chatCache, mapDataCache, recipeCache, teamCache, scoreboardCache);
     }
 
     public boolean reset(boolean full) {

--- a/src/main/java/com/zenith/cache/data/scoreboard/Objective.java
+++ b/src/main/java/com/zenith/cache/data/scoreboard/Objective.java
@@ -3,6 +3,8 @@ package com.zenith.cache.data.scoreboard;
 import com.github.steveice10.mc.protocol.data.game.scoreboard.ObjectiveAction;
 import com.github.steveice10.mc.protocol.data.game.scoreboard.ScoreType;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetObjectivePacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetScorePacket;
+import com.github.steveice10.packetlib.packet.Packet;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import lombok.Getter;
@@ -11,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import net.kyori.adventure.text.Component;
+
+import java.util.function.Consumer;
 
 @Getter
 @Setter
@@ -25,12 +29,15 @@ public class Objective {
 
     protected final Object2IntMap<String> scores = new Object2IntOpenHashMap<>();
 
-    public ClientboundSetObjectivePacket toPacket() {
-        return new ClientboundSetObjectivePacket(
+    public void addPackets(Consumer<Packet> consumer) {
+        consumer.accept(new ClientboundSetObjectivePacket(
                 this.name,
                 ObjectiveAction.ADD,
                 this.displayName,
                 this.scoreType
-        );
+        ));
+        for (var entry : this.scores.object2IntEntrySet()) {
+            consumer.accept(new ClientboundSetScorePacket(entry.getKey(), this.name, entry.getIntValue()));
+        }
     }
 }

--- a/src/main/java/com/zenith/cache/data/scoreboard/Objective.java
+++ b/src/main/java/com/zenith/cache/data/scoreboard/Objective.java
@@ -1,0 +1,36 @@
+package com.zenith.cache.data.scoreboard;
+
+import com.github.steveice10.mc.protocol.data.game.scoreboard.ObjectiveAction;
+import com.github.steveice10.mc.protocol.data.game.scoreboard.ScoreType;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetObjectivePacket;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import net.kyori.adventure.text.Component;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@RequiredArgsConstructor
+public class Objective {
+    @NonNull
+    protected final String name;
+
+    protected Component displayName;
+    protected ScoreType scoreType;
+
+    protected final Object2IntMap<String> scores = new Object2IntOpenHashMap<>();
+
+    public ClientboundSetObjectivePacket toPacket() {
+        return new ClientboundSetObjectivePacket(
+                this.name,
+                ObjectiveAction.ADD,
+                this.displayName,
+                this.scoreType
+        );
+    }
+}

--- a/src/main/java/com/zenith/cache/data/scoreboard/ScoreboardCache.java
+++ b/src/main/java/com/zenith/cache/data/scoreboard/ScoreboardCache.java
@@ -1,0 +1,68 @@
+package com.zenith.cache.data.scoreboard;
+
+import com.github.steveice10.mc.protocol.data.game.scoreboard.ScoreboardPosition;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetDisplayObjectivePacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetObjectivePacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetScorePacket;
+import com.github.steveice10.packetlib.packet.Packet;
+import com.zenith.cache.CachedData;
+import lombok.NonNull;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+public class ScoreboardCache implements CachedData {
+    protected final Map<String, Objective> cachedObjectives = new ConcurrentHashMap<>();
+    protected final Map<ScoreboardPosition, String> cachedPositionObjectives = new EnumMap<>(ScoreboardPosition.class);
+
+    @Override
+    public void getPackets(@NonNull Consumer<Packet> consumer) {
+        for (final Objective objective : this.cachedObjectives.values()) {
+            consumer.accept(objective.toPacket());
+            objective.getScores().forEach((entry, value) -> consumer.accept(new ClientboundSetScorePacket(entry, objective.getName(), value)));
+        }
+        this.cachedPositionObjectives.forEach((pos, objective) -> consumer.accept(new ClientboundSetDisplayObjectivePacket(pos, objective)));
+    }
+
+    @Override
+    public void reset(boolean full) {
+        if (full) {
+            this.cachedObjectives.clear();
+            this.cachedPositionObjectives.clear();
+        }
+    }
+
+    @Override
+    public String getSendingMessage() {
+        return String.format("Sending %d scoreboard objectives", this.cachedObjectives.size());
+    }
+
+    public void setPositionObjective(ScoreboardPosition position, String objective) {
+        this.cachedPositionObjectives.put(position, objective);
+    }
+
+    public void add(@NonNull ClientboundSetObjectivePacket packet) {
+        this.cachedObjectives.put(
+                packet.getName(),
+                new Objective(packet.getName())
+                        .setDisplayName(packet.getDisplayName())
+                        .setScoreType(packet.getType())
+        );
+    }
+
+    public void remove(@NonNull ClientboundSetObjectivePacket packet) {
+        this.cachedObjectives.remove(packet.getName());
+    }
+
+    public void removeEntry(@NonNull String entry) {
+        for (final Objective objective : this.cachedObjectives.values()) {
+            objective.getScores().removeInt(entry);
+        }
+    }
+
+    public Objective get(@NonNull String name) {
+        return this.cachedObjectives.get(name);
+    }
+}

--- a/src/main/java/com/zenith/cache/data/scoreboard/ScoreboardCache.java
+++ b/src/main/java/com/zenith/cache/data/scoreboard/ScoreboardCache.java
@@ -3,7 +3,6 @@ package com.zenith.cache.data.scoreboard;
 import com.github.steveice10.mc.protocol.data.game.scoreboard.ScoreboardPosition;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetDisplayObjectivePacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetObjectivePacket;
-import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetScorePacket;
 import com.github.steveice10.packetlib.packet.Packet;
 import com.zenith.cache.CachedData;
 import lombok.NonNull;
@@ -20,8 +19,7 @@ public class ScoreboardCache implements CachedData {
     @Override
     public void getPackets(@NonNull Consumer<Packet> consumer) {
         for (final Objective objective : this.cachedObjectives.values()) {
-            consumer.accept(objective.toPacket());
-            objective.getScores().forEach((entry, value) -> consumer.accept(new ClientboundSetScorePacket(entry, objective.getName(), value)));
+            objective.addPackets(consumer);
         }
         this.cachedPositionObjectives.forEach((pos, objective) -> consumer.accept(new ClientboundSetDisplayObjectivePacket(pos, objective)));
     }

--- a/src/main/java/com/zenith/cache/data/team/Team.java
+++ b/src/main/java/com/zenith/cache/data/team/Team.java
@@ -4,14 +4,13 @@ import com.github.steveice10.mc.protocol.data.game.scoreboard.CollisionRule;
 import com.github.steveice10.mc.protocol.data.game.scoreboard.NameTagVisibility;
 import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamColor;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetPlayerTeamPacket;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import net.kyori.adventure.text.Component;
-
-import java.util.List;
 
 
 @Getter
@@ -30,7 +29,7 @@ public class Team {
     protected NameTagVisibility nameTagVisibility;
     protected CollisionRule collisionRule;
     protected TeamColor color;
-    protected List<String> players;
+    protected ObjectSet<String> players;
 
     public ClientboundSetPlayerTeamPacket toPacket() {
         return new ClientboundSetPlayerTeamPacket(

--- a/src/main/java/com/zenith/cache/data/team/Team.java
+++ b/src/main/java/com/zenith/cache/data/team/Team.java
@@ -1,0 +1,49 @@
+package com.zenith.cache.data.team;
+
+import com.github.steveice10.mc.protocol.data.game.scoreboard.CollisionRule;
+import com.github.steveice10.mc.protocol.data.game.scoreboard.NameTagVisibility;
+import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamColor;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetPlayerTeamPacket;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import net.kyori.adventure.text.Component;
+
+import java.util.List;
+
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@RequiredArgsConstructor
+public class Team {
+    @NonNull
+    protected final String teamName;
+
+    protected Component displayName;
+    protected Component prefix;
+    protected Component suffix;
+    protected boolean friendlyFire;
+    protected boolean seeFriendlyInvisibles;
+    protected NameTagVisibility nameTagVisibility;
+    protected CollisionRule collisionRule;
+    protected TeamColor color;
+    protected List<String> players;
+
+    public ClientboundSetPlayerTeamPacket toPacket() {
+        return new ClientboundSetPlayerTeamPacket(
+                this.teamName,
+                this.displayName,
+                this.prefix,
+                this.suffix,
+                this.friendlyFire,
+                this.seeFriendlyInvisibles,
+                this.nameTagVisibility,
+                this.collisionRule,
+                this.color,
+                this.players.toArray(new String[0])
+        );
+    }
+}

--- a/src/main/java/com/zenith/cache/data/team/Team.java
+++ b/src/main/java/com/zenith/cache/data/team/Team.java
@@ -40,9 +40,9 @@ public class Team {
                 this.suffix,
                 this.friendlyFire,
                 this.seeFriendlyInvisibles,
-                this.nameTagVisibility,
-                this.collisionRule,
-                this.color,
+                this.nameTagVisibility != null ? this.nameTagVisibility : NameTagVisibility.HIDE_FOR_OTHER_TEAMS,
+                this.collisionRule != null ? this.collisionRule : CollisionRule.ALWAYS,
+                this.color != null ? this.color : TeamColor.WHITE,
                 this.players.toArray(new String[0])
         );
     }

--- a/src/main/java/com/zenith/cache/data/team/TeamCache.java
+++ b/src/main/java/com/zenith/cache/data/team/TeamCache.java
@@ -1,0 +1,57 @@
+package com.zenith.cache.data.team;
+
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetPlayerTeamPacket;
+import com.github.steveice10.packetlib.packet.Packet;
+import com.zenith.cache.CachedData;
+import lombok.NonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+public class TeamCache implements CachedData {
+    protected final Map<String, Team> cachedTeams = new ConcurrentHashMap<>();
+
+    @Override
+    public void getPackets(@NonNull Consumer<Packet> consumer) {
+        this.cachedTeams.values().stream().map(Team::toPacket).forEach(consumer);
+    }
+
+    @Override
+    public void reset(boolean full) {
+        if (full) {
+            this.cachedTeams.clear();
+        }
+    }
+
+    @Override
+    public String getSendingMessage() {
+        return String.format("Sending %d teams", this.cachedTeams.size());
+    }
+
+    public void add(@NonNull ClientboundSetPlayerTeamPacket packet) {
+        this.cachedTeams.put(
+                packet.getTeamName(),
+                new Team(packet.getTeamName())
+                        .setDisplayName(packet.getDisplayName())
+                        .setPrefix(packet.getPrefix())
+                        .setSuffix(packet.getSuffix())
+                        .setFriendlyFire(packet.isFriendlyFire())
+                        .setSeeFriendlyInvisibles(packet.isSeeFriendlyInvisibles())
+                        .setNameTagVisibility(packet.getNameTagVisibility())
+                        .setCollisionRule(packet.getCollisionRule())
+                        .setColor(packet.getColor())
+                        .setPlayers(new ArrayList<>(Arrays.asList(packet.getPlayers())))
+        );
+    }
+
+    public void remove(@NonNull ClientboundSetPlayerTeamPacket packet) {
+        this.cachedTeams.remove(packet.getTeamName());
+    }
+
+    public Team get(@NonNull ClientboundSetPlayerTeamPacket packet) {
+        return this.cachedTeams.get(packet.getTeamName());
+    }
+}

--- a/src/main/java/com/zenith/cache/data/team/TeamCache.java
+++ b/src/main/java/com/zenith/cache/data/team/TeamCache.java
@@ -3,10 +3,9 @@ package com.zenith.cache.data.team;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetPlayerTeamPacket;
 import com.github.steveice10.packetlib.packet.Packet;
 import com.zenith.cache.CachedData;
+import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import lombok.NonNull;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -43,7 +42,7 @@ public class TeamCache implements CachedData {
                         .setNameTagVisibility(packet.getNameTagVisibility())
                         .setCollisionRule(packet.getCollisionRule())
                         .setColor(packet.getColor())
-                        .setPlayers(new ArrayList<>(Arrays.asList(packet.getPlayers())))
+                        .setPlayers(ObjectArraySet.of(packet.getPlayers()))
         );
     }
 

--- a/src/main/java/com/zenith/network/client/handler/incoming/TeamHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/TeamHandler.java
@@ -1,0 +1,44 @@
+package com.zenith.network.client.handler.incoming;
+
+import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamAction;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetPlayerTeamPacket;
+import com.zenith.cache.data.team.Team;
+import com.zenith.network.client.ClientSession;
+import com.zenith.network.registry.AsyncPacketHandler;
+import lombok.NonNull;
+
+import java.util.Arrays;
+
+import static com.zenith.Shared.CACHE;
+
+public class TeamHandler implements AsyncPacketHandler<ClientboundSetPlayerTeamPacket, ClientSession> {
+    @Override
+    public boolean applyAsync(@NonNull ClientboundSetPlayerTeamPacket packet, @NonNull ClientSession session) {
+        if (packet.getAction() == TeamAction.CREATE) {
+            CACHE.getTeamCache().add(packet);
+        } else if (packet.getAction() == TeamAction.REMOVE) {
+            CACHE.getTeamCache().remove(packet);
+        } else {
+            final Team team = CACHE.getTeamCache().get(packet);
+            if (team == null) {
+                return false;
+            }
+
+            switch (packet.getAction()) {
+                case UPDATE -> {
+                    team.setDisplayName(packet.getDisplayName());
+                    team.setPrefix(packet.getPrefix());
+                    team.setSuffix(packet.getSuffix());
+                    team.setFriendlyFire(packet.isFriendlyFire());
+                    team.setSeeFriendlyInvisibles(packet.isSeeFriendlyInvisibles());
+                    team.setNameTagVisibility(packet.getNameTagVisibility());
+                    team.setCollisionRule(packet.getCollisionRule());
+                    team.setColor(packet.getColor());
+                }
+                case ADD_PLAYER -> team.getPlayers().addAll(Arrays.asList(packet.getPlayers()));
+                case REMOVE_PLAYER -> team.getPlayers().removeAll(Arrays.asList(packet.getPlayers()));
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetDisplayObjectiveHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetDisplayObjectiveHandler.java
@@ -1,0 +1,16 @@
+package com.zenith.network.client.handler.incoming.scoreboard;
+
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetDisplayObjectivePacket;
+import com.zenith.network.client.ClientSession;
+import com.zenith.network.registry.AsyncPacketHandler;
+import lombok.NonNull;
+
+import static com.zenith.Shared.CACHE;
+
+public class SetDisplayObjectiveHandler implements AsyncPacketHandler<ClientboundSetDisplayObjectivePacket, ClientSession> {
+    @Override
+    public boolean applyAsync(@NonNull ClientboundSetDisplayObjectivePacket packet, @NonNull ClientSession session) {
+        CACHE.getScoreboardCache().setPositionObjective(packet.getPosition(), packet.getName());
+        return true;
+    }
+}

--- a/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetObjectiveHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetObjectiveHandler.java
@@ -1,0 +1,30 @@
+package com.zenith.network.client.handler.incoming.scoreboard;
+
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetObjectivePacket;
+import com.zenith.cache.data.scoreboard.Objective;
+import com.zenith.network.client.ClientSession;
+import com.zenith.network.registry.AsyncPacketHandler;
+import lombok.NonNull;
+
+import static com.zenith.Shared.CACHE;
+
+public class SetObjectiveHandler implements AsyncPacketHandler<ClientboundSetObjectivePacket, ClientSession> {
+    @Override
+    public boolean applyAsync(@NonNull ClientboundSetObjectivePacket packet, @NonNull ClientSession session) {
+        switch (packet.getAction()) {
+            case ADD -> CACHE.getScoreboardCache().add(packet);
+            case REMOVE -> CACHE.getScoreboardCache().remove(packet);
+            case UPDATE -> {
+                final Objective objective = CACHE.getScoreboardCache().get(packet.getName());
+                if (objective == null) {
+                    return false;
+                }
+
+                objective.setDisplayName(packet.getDisplayName());
+                objective.setScoreType(packet.getType());
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetObjectiveHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetObjectiveHandler.java
@@ -19,9 +19,9 @@ public class SetObjectiveHandler implements AsyncPacketHandler<ClientboundSetObj
                 if (objective == null) {
                     return false;
                 }
-
-                objective.setDisplayName(packet.getDisplayName());
-                objective.setScoreType(packet.getType());
+                objective
+                    .setDisplayName(packet.getDisplayName())
+                    .setScoreType(packet.getType());
             }
         }
 

--- a/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetScoreHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetScoreHandler.java
@@ -1,0 +1,30 @@
+package com.zenith.network.client.handler.incoming.scoreboard;
+
+import com.github.steveice10.mc.protocol.data.game.scoreboard.ScoreboardAction;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetScorePacket;
+import com.zenith.cache.data.scoreboard.Objective;
+import com.zenith.network.client.ClientSession;
+import com.zenith.network.registry.AsyncPacketHandler;
+import lombok.NonNull;
+
+import static com.zenith.Shared.CACHE;
+
+public class SetScoreHandler implements AsyncPacketHandler<ClientboundSetScorePacket, ClientSession> {
+    @Override
+    public boolean applyAsync(@NonNull ClientboundSetScorePacket packet, @NonNull ClientSession session) {
+        if (packet.getObjective().isEmpty() && packet.getAction() == ScoreboardAction.REMOVE) {
+            CACHE.getScoreboardCache().removeEntry(packet.getEntry());
+        } else {
+            final Objective objective = CACHE.getScoreboardCache().get(packet.getObjective());
+            if (objective == null) {
+                return false;
+            }
+
+            switch (packet.getAction()) {
+                case ADD_OR_UPDATE -> objective.getScores().put(packet.getEntry(), packet.getValue());
+                case REMOVE -> objective.getScores().removeInt(packet.getEntry());
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetScoreHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/SetScoreHandler.java
@@ -1,8 +1,6 @@
 package com.zenith.network.client.handler.incoming.scoreboard;
 
-import com.github.steveice10.mc.protocol.data.game.scoreboard.ScoreboardAction;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetScorePacket;
-import com.zenith.cache.data.scoreboard.Objective;
 import com.zenith.network.client.ClientSession;
 import com.zenith.network.registry.AsyncPacketHandler;
 import lombok.NonNull;
@@ -12,17 +10,12 @@ import static com.zenith.Shared.CACHE;
 public class SetScoreHandler implements AsyncPacketHandler<ClientboundSetScorePacket, ClientSession> {
     @Override
     public boolean applyAsync(@NonNull ClientboundSetScorePacket packet, @NonNull ClientSession session) {
-        if (packet.getObjective().isEmpty() && packet.getAction() == ScoreboardAction.REMOVE) {
-            CACHE.getScoreboardCache().removeEntry(packet.getEntry());
-        } else {
-            final Objective objective = CACHE.getScoreboardCache().get(packet.getObjective());
-            if (objective == null) {
-                return false;
-            }
-
-            switch (packet.getAction()) {
-                case ADD_OR_UPDATE -> objective.getScores().put(packet.getEntry(), packet.getValue());
-                case REMOVE -> objective.getScores().removeInt(packet.getEntry());
+        switch (packet.getAction()) {
+            case REMOVE -> CACHE.getScoreboardCache().removeEntry(packet.getEntry());
+            case ADD_OR_UPDATE -> {
+                var objective = CACHE.getScoreboardCache().get(packet.getObjective());
+                if (objective == null) return false;
+                objective.getScores().put(packet.getEntry(), packet.getValue());
             }
         }
         return true;

--- a/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/TeamHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/TeamHandler.java
@@ -1,42 +1,42 @@
 package com.zenith.network.client.handler.incoming.scoreboard;
 
-import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamAction;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetPlayerTeamPacket;
-import com.zenith.cache.data.team.Team;
 import com.zenith.network.client.ClientSession;
 import com.zenith.network.registry.AsyncPacketHandler;
 import lombok.NonNull;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import static com.zenith.Shared.CACHE;
 
 public class TeamHandler implements AsyncPacketHandler<ClientboundSetPlayerTeamPacket, ClientSession> {
     @Override
     public boolean applyAsync(@NonNull ClientboundSetPlayerTeamPacket packet, @NonNull ClientSession session) {
-        if (packet.getAction() == TeamAction.CREATE) {
-            CACHE.getTeamCache().add(packet);
-        } else if (packet.getAction() == TeamAction.REMOVE) {
-            CACHE.getTeamCache().remove(packet);
-        } else {
-            final Team team = CACHE.getTeamCache().get(packet);
-            if (team == null) {
-                return false;
+        switch (packet.getAction()) {
+            case CREATE -> CACHE.getTeamCache().add(packet);
+            case REMOVE -> CACHE.getTeamCache().remove(packet);
+            case UPDATE -> {
+                var team = CACHE.getTeamCache().get(packet);
+                if (team == null) return false;
+                team.setDisplayName(packet.getDisplayName())
+                    .setPrefix(packet.getPrefix())
+                    .setSuffix(packet.getSuffix())
+                    .setFriendlyFire(packet.isFriendlyFire())
+                    .setSeeFriendlyInvisibles(packet.isSeeFriendlyInvisibles())
+                    .setNameTagVisibility(packet.getNameTagVisibility())
+                    .setCollisionRule(packet.getCollisionRule())
+                    .setColor(packet.getColor());
             }
-
-            switch (packet.getAction()) {
-                case UPDATE -> {
-                    team.setDisplayName(packet.getDisplayName());
-                    team.setPrefix(packet.getPrefix());
-                    team.setSuffix(packet.getSuffix());
-                    team.setFriendlyFire(packet.isFriendlyFire());
-                    team.setSeeFriendlyInvisibles(packet.isSeeFriendlyInvisibles());
-                    team.setNameTagVisibility(packet.getNameTagVisibility());
-                    team.setCollisionRule(packet.getCollisionRule());
-                    team.setColor(packet.getColor());
-                }
-                case ADD_PLAYER -> team.getPlayers().addAll(Arrays.asList(packet.getPlayers()));
-                case REMOVE_PLAYER -> team.getPlayers().removeAll(Arrays.asList(packet.getPlayers()));
+            case ADD_PLAYER -> {
+                var team = CACHE.getTeamCache().get(packet);
+                if (team == null) return false;
+                Collections.addAll(team.getPlayers(), packet.getPlayers());
+            }
+            case REMOVE_PLAYER -> {
+                var team = CACHE.getTeamCache().get(packet);
+                if (team == null) return false;
+                var players = team.getPlayers();
+                for (String p : packet.getPlayers()) players.remove(p);
             }
         }
         return true;

--- a/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/TeamHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/scoreboard/TeamHandler.java
@@ -1,4 +1,4 @@
-package com.zenith.network.client.handler.incoming;
+package com.zenith.network.client.handler.incoming.scoreboard;
 
 import com.github.steveice10.mc.protocol.data.game.scoreboard.TeamAction;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.scoreboard.ClientboundSetPlayerTeamPacket;


### PR DESCRIPTION
Allows scoreboards and teams to be shown correctly when connecting when the proxy is already logged into the target server.

Scoreboards have changed a bit in 1.20.3 and the packet handling (mostly near the score handling) will need to be changed a bit when updating past that version. I can submit another PR targeting the 1.20.4 branch if needed.

I split team & scoreboard handling into separate "Cache" classes, I'm not sure if it'd be preferred if they were merged into one.

Resolves #70 