### PR TITLE
Implement world time caching

### DIFF
--- a/src/main/java/com/zenith/cache/data/chunk/ChunkCache.java
+++ b/src/main/java/com/zenith/cache/data/chunk/ChunkCache.java
@@ -70,6 +70,7 @@ public class ChunkCache implements CachedData {
     // todo: also cache world border size changes
     //  doesn't particularly matter on 2b2t tho
     protected WorldBorderData worldBorderData = WorldBorderData.DEFAULT;
+    protected WorldTimeData worldTimeData;
     protected byte[] serverBrand = BRAND_SUPPLIER.get();
 
     public ChunkCache() {
@@ -349,6 +350,9 @@ public class ChunkCache implements CachedData {
                                                                    worldBorderData.getWarningTime()));
             consumer.accept(new ClientboundSetChunkCacheRadiusPacket(serverViewDistance));
             consumer.accept(new ClientboundSetChunkCacheCenterPacket(centerX, centerZ));
+            if (this.worldTimeData != null) {
+                consumer.accept(this.worldTimeData.toPacket());
+            }
             readCache(() -> {
                 for (final Chunk chunk : this.cache.values()) {
                     consumer.accept(new ClientboundLevelChunkWithLightPacket(

--- a/src/main/java/com/zenith/cache/data/chunk/ChunkCache.java
+++ b/src/main/java/com/zenith/cache/data/chunk/ChunkCache.java
@@ -535,4 +535,9 @@ public class ChunkCache implements CachedData {
                                        packet.isFlat());
         CACHE_LOG.debug("Updated current dimension to {}", currentDimension.dimensionName);
     }
+
+    public void updateWorldTime(final ClientboundSetTimePacket packet) {
+        if (this.worldTimeData == null) this.worldTimeData = new WorldTimeData();
+        else this.worldTimeData.update(packet);
+    }
 }

--- a/src/main/java/com/zenith/cache/data/chunk/ChunkCache.java
+++ b/src/main/java/com/zenith/cache/data/chunk/ChunkCache.java
@@ -392,6 +392,7 @@ public class ChunkCache implements CachedData {
                 this.serverSimulationDistance = -1;
                 this.registryTag = null;
                 this.worldBorderData = WorldBorderData.DEFAULT;
+                this.worldTimeData = null;
                 this.serverBrand = BRAND_SUPPLIER.get();
             }
             return true;

--- a/src/main/java/com/zenith/cache/data/chunk/WorldTimeData.java
+++ b/src/main/java/com/zenith/cache/data/chunk/WorldTimeData.java
@@ -1,0 +1,30 @@
+package com.zenith.cache.data.chunk;
+
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.ClientboundSetTimePacket;
+
+public record WorldTimeData(long lastUpdate, long worldAge, long time) {
+    public WorldTimeData(ClientboundSetTimePacket packet) {
+        this(System.nanoTime(), packet.getWorldAge(), packet.getTime());
+    }
+
+    public ClientboundSetTimePacket toPacket() {
+        // The amount of ticks that have passed since the last time packet was received.
+        final long offset = (System.nanoTime() - this.lastUpdate) / 50000000;
+
+        long worldAge = this.worldAge;
+
+        if (worldAge > 0) {
+            worldAge += offset;
+        }
+
+        long time = this.time;
+
+        // If time is negative, the daylight cycle is disabled (e.g. from the "doDaylightCycle" gamerule being false)
+        if (time >= 0) {
+            time += offset;
+            time %= 24000;
+        }
+
+        return new ClientboundSetTimePacket(worldAge, time);
+    }
+}

--- a/src/main/java/com/zenith/cache/data/chunk/WorldTimeData.java
+++ b/src/main/java/com/zenith/cache/data/chunk/WorldTimeData.java
@@ -2,9 +2,15 @@ package com.zenith.cache.data.chunk;
 
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.ClientboundSetTimePacket;
 
-public record WorldTimeData(long lastUpdate, long worldAge, long time) {
-    public WorldTimeData(ClientboundSetTimePacket packet) {
-        this(System.nanoTime(), packet.getWorldAge(), packet.getTime());
+public class WorldTimeData {
+    private long lastUpdate;
+    private long worldAge;
+    private long time;
+
+    public void update(ClientboundSetTimePacket packet) {
+        this.lastUpdate = System.nanoTime();
+        this.worldAge = packet.getWorldAge();
+        this.time = packet.getTime();
     }
 
     public ClientboundSetTimePacket toPacket() {

--- a/src/main/java/com/zenith/network/client/handler/incoming/SetTimeHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/SetTimeHandler.java
@@ -12,7 +12,11 @@ public class SetTimeHandler implements AsyncPacketHandler<ClientboundSetTimePack
 
     @Override
     public boolean applyAsync(ClientboundSetTimePacket packet, ClientSession session) {
-        CACHE.getChunkCache().setWorldTimeData(new WorldTimeData(packet));
+        if (CACHE.getChunkCache().getWorldTimeData() == null) {
+            CACHE.getChunkCache().setWorldTimeData(new WorldTimeData());
+        }
+        CACHE.getChunkCache().getWorldTimeData().update(packet);
+
         TPS_CALCULATOR.handleTimeUpdate(packet);
         return true;
     }

--- a/src/main/java/com/zenith/network/client/handler/incoming/SetTimeHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/SetTimeHandler.java
@@ -1,7 +1,6 @@
 package com.zenith.network.client.handler.incoming;
 
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.ClientboundSetTimePacket;
-import com.zenith.cache.data.chunk.WorldTimeData;
 import com.zenith.network.client.ClientSession;
 import com.zenith.network.registry.AsyncPacketHandler;
 
@@ -12,11 +11,7 @@ public class SetTimeHandler implements AsyncPacketHandler<ClientboundSetTimePack
 
     @Override
     public boolean applyAsync(ClientboundSetTimePacket packet, ClientSession session) {
-        if (CACHE.getChunkCache().getWorldTimeData() == null) {
-            CACHE.getChunkCache().setWorldTimeData(new WorldTimeData());
-        }
-        CACHE.getChunkCache().getWorldTimeData().update(packet);
-
+        CACHE.getChunkCache().updateWorldTime(packet);
         TPS_CALCULATOR.handleTimeUpdate(packet);
         return true;
     }

--- a/src/main/java/com/zenith/network/client/handler/incoming/SetTimeHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/SetTimeHandler.java
@@ -1,15 +1,18 @@
 package com.zenith.network.client.handler.incoming;
 
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.ClientboundSetTimePacket;
+import com.zenith.cache.data.chunk.WorldTimeData;
 import com.zenith.network.client.ClientSession;
 import com.zenith.network.registry.AsyncPacketHandler;
 
+import static com.zenith.Shared.CACHE;
 import static com.zenith.Shared.TPS_CALCULATOR;
 
 public class SetTimeHandler implements AsyncPacketHandler<ClientboundSetTimePacket, ClientSession> {
 
     @Override
     public boolean applyAsync(ClientboundSetTimePacket packet, ClientSession session) {
+        CACHE.getChunkCache().setWorldTimeData(new WorldTimeData(packet));
         TPS_CALCULATOR.handleTimeUpdate(packet);
         return true;
     }


### PR DESCRIPTION
Fixes world time being incorrect when joining the proxy, then suddenly jumping to the correct time when the server sends the next SetTime packet.

In Minecraft by default, this packet is sent every second so this isn't too noticeable. But on some servers, this packet is sent much less frequently (e.g. every minute), and so the time on the client can be incorrect for a while.

I've added this data in the ChunkCache as that's where some existing world-related data such as the world border is stored.