### PR TITLE
Add Discord DM control support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,7 @@
 name: ZenithProxy Build
 
 on:
-  pull_request:
-  push:
-    branches:
-      - "1.20.1"
+  workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/jar-release.yml
+++ b/.github/workflows/jar-release.yml
@@ -1,9 +1,9 @@
 name: ZenithProxy Java Build And Release
 
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+\+java.1.20.1'
+  workflow_dispatch
+
+
 
 jobs:
   build:

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -141,11 +141,14 @@ public class DiscordBot {
             if (CONFIG.discord.chatRelay.channelId.isEmpty()) throw new RuntimeException("Discord chat relay is enabled and channel id is not set");
             if (CONFIG.discord.channelId.equals(CONFIG.discord.chatRelay.channelId)) throw new RuntimeException("Discord channel id and chat relay channel id cannot be the same");
         }
-        if (CONFIG.discord.accountOwnerRoleId.isEmpty()) throw new RuntimeException("Discord account owner role id is not set");
-        try {
-            Snowflake.of(CONFIG.discord.accountOwnerRoleId);
-        } catch (final NumberFormatException e) {
-            throw new RuntimeException("Invalid account owner role ID set: " + CONFIG.discord.accountOwnerRoleId);
+        if (CONFIG.discord.accountOwnerRoleId.isEmpty()) 
+            DISCORD_LOG.error("Discord account owner role id is not set. Bot can be controlled by anyone.");
+        else {
+            try {
+                Snowflake.of(CONFIG.discord.accountOwnerRoleId);
+            } catch (final NumberFormatException e) {
+                throw new RuntimeException("Invalid account owner role ID set: " + CONFIG.discord.accountOwnerRoleId);
+            }
         }
         DiscordClient discordClient = buildProxiedClient(DiscordClientBuilder.create(CONFIG.discord.token)).build();
         this.client = discordClient.gateway()

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -142,7 +142,7 @@ public class DiscordBot {
             if (CONFIG.discord.channelId.equals(CONFIG.discord.chatRelay.channelId)) throw new RuntimeException("Discord channel id and chat relay channel id cannot be the same");
         }
         if (CONFIG.discord.accountOwnerRoleId.isEmpty()) 
-            DISCORD_LOG.error("Discord account owner role id is not set. Bot can be controlled by anyone");
+            DISCORD_LOG.error("Discord account owner role id is not set. Roles will not be checked");
         else {
             try {
                 Snowflake.of(CONFIG.discord.accountOwnerRoleId);
@@ -183,6 +183,8 @@ public class DiscordBot {
                 final String inputMessage = message.substring(1);
                 if (!CONFIG.discord.accountOwnerRoleId.isEmpty())
                     DISCORD_LOG.info(event.getMember().map(User::getTag).orElse("unknown user") + " (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
+                else
+                    DISCORD_LOG.info(" (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
                 final CommandContext context = DiscordCommandContext.create(inputMessage, event, mainRestChannel);
                 COMMAND_MANAGER.execute(context);
                 final MultipartRequest<MessageCreateRequest> request = commandEmbedOutputToMessage(context);

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -184,7 +184,7 @@ public class DiscordBot {
                 if (!CONFIG.discord.accountOwnerRoleId.isEmpty())
                     DISCORD_LOG.info(event.getMember().map(User::getTag).orElse("unknown user") + " (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
                 else
-                    DISCORD_LOG.info(" (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
+                    DISCORD_LOG.info(" (" + event.getMessage().getAuthor() + ") executed discord command: {}", inputMessage);
                 final CommandContext context = DiscordCommandContext.create(inputMessage, event, mainRestChannel);
                 COMMAND_MANAGER.execute(context);
                 final MultipartRequest<MessageCreateRequest> request = commandEmbedOutputToMessage(context);

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -142,12 +142,13 @@ public class DiscordBot {
             if (CONFIG.discord.channelId.equals(CONFIG.discord.chatRelay.channelId)) throw new RuntimeException("Discord channel id and chat relay channel id cannot be the same");
         }
         if (CONFIG.discord.accountOwnerRoleId.isEmpty()) 
-            DISCORD_LOG.error("Discord account owner role id is not set. Roles will not be checked");
+            DISCORD_LOG.warn("Discord account owner role id is not set. Roles will not be checked");
         else {
             try {
                 Snowflake.of(CONFIG.discord.accountOwnerRoleId);
             } catch (final NumberFormatException e) {
                 throw new RuntimeException("Invalid account owner role ID set: " + CONFIG.discord.accountOwnerRoleId);
+            }
         }
         DiscordClient discordClient = buildProxiedClient(DiscordClientBuilder.create(CONFIG.discord.token)).build();
         this.client = discordClient.gateway()

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -179,7 +179,7 @@ public class DiscordBot {
                 if (!CONFIG.discord.accountOwnerRoleId.isEmpty())
                     DISCORD_LOG.info(event.getMember().map(User::getTag).orElse("unknown user") + " (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
                 else
-                    DISCORD_LOG.info(event.getMessage().getAuthor().getUsername() + " executed discord command: {}", inputMessage);
+                    DISCORD_LOG.info(event.getMessage().getAuthor().get().getUsername() + " executed discord command: {}", inputMessage);
                 final CommandContext context = DiscordCommandContext.create(inputMessage, event, mainRestChannel);
                 COMMAND_MANAGER.execute(context);
                 final MultipartRequest<MessageCreateRequest> request = commandEmbedOutputToMessage(context);

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -161,22 +161,17 @@ public class DiscordBot {
         mainRestChannel = restClient.getChannelById(Snowflake.of(CONFIG.discord.channelId));
         relayRestChannel = restClient.getChannelById(Snowflake.of(CONFIG.discord.chatRelay.channelId));
         client.getEventDispatcher().on(MessageCreateEvent.class).subscribe(event -> {
-            DISCORD_LOG.error("GOT A MESSAGE!!!");
             if (CONFIG.discord.chatRelay.enable && !CONFIG.discord.chatRelay.channelId.isEmpty() && event.getMessage().getChannelId().equals(Snowflake.of(CONFIG.discord.chatRelay.channelId))) {
-                DISCORD_LOG.error("IM CHECKING IT NOW");
                 if (!event.getMember().get().getId().equals(this.client.getSelfId())) {
-                    DISCORD_LOG.error("AND IT PASSED ALL CHECKS!!!");
                     EVENT_BUS.postAsync(new DiscordMessageSentEvent(sanitizeRelayInputMessage(event.getMessage().getContent()), event));
                     return;
                 }
             }
             if (!event.getMessage().getChannelId().equals(Snowflake.of(CONFIG.discord.channelId))) {
-                DISCORD_LOG.error("IT WAS NOT IN THE RIGHT CHANNEL");
                 return;
             }
             final String message = event.getMessage().getContent();
             if (!message.startsWith(CONFIG.discord.prefix)) {
-                DISCORD_LOG.error("IT DID NOT HAVE THE RIGHT PREFIX");
                 return;
             }
             try {
@@ -184,7 +179,7 @@ public class DiscordBot {
                 if (!CONFIG.discord.accountOwnerRoleId.isEmpty())
                     DISCORD_LOG.info(event.getMember().map(User::getTag).orElse("unknown user") + " (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
                 else
-                    DISCORD_LOG.info(" (" + event.getMessage().getAuthor() + ") executed discord command: {}", inputMessage);
+                    DISCORD_LOG.info(event.getMessage().getAuthor().getUsername() + " executed discord command: {}", inputMessage);
                 final CommandContext context = DiscordCommandContext.create(inputMessage, event, mainRestChannel);
                 COMMAND_MANAGER.execute(context);
                 final MultipartRequest<MessageCreateRequest> request = commandEmbedOutputToMessage(context);

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -181,7 +181,8 @@ public class DiscordBot {
             }
             try {
                 final String inputMessage = message.substring(1);
-                DISCORD_LOG.info(event.getMember().map(User::getTag).orElse("unknown user") + " (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
+                if (!CONFIG.discord.accountOwnerRoleId.isEmpty())
+                    DISCORD_LOG.info(event.getMember().map(User::getTag).orElse("unknown user") + " (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
                 final CommandContext context = DiscordCommandContext.create(inputMessage, event, mainRestChannel);
                 COMMAND_MANAGER.execute(context);
                 final MultipartRequest<MessageCreateRequest> request = commandEmbedOutputToMessage(context);

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -141,16 +141,18 @@ public class DiscordBot {
             if (CONFIG.discord.chatRelay.channelId.isEmpty()) throw new RuntimeException("Discord chat relay is enabled and channel id is not set");
             if (CONFIG.discord.channelId.equals(CONFIG.discord.chatRelay.channelId)) throw new RuntimeException("Discord channel id and chat relay channel id cannot be the same");
         }
-        if (CONFIG.discord.accountOwnerRoleId.isEmpty()) throw new RuntimeException("Discord account owner role id is not set");
-        try {
-            Snowflake.of(CONFIG.discord.accountOwnerRoleId);
-        } catch (final NumberFormatException e) {
-            throw new RuntimeException("Invalid account owner role ID set: " + CONFIG.discord.accountOwnerRoleId);
+        if (CONFIG.discord.accountOwnerRoleId.isEmpty()) 
+            DISCORD_LOG.error("Discord account owner role id is not set. Roles will not be checked");
+        else {
+            try {
+                Snowflake.of(CONFIG.discord.accountOwnerRoleId);
+            } catch (final NumberFormatException e) {
+                throw new RuntimeException("Invalid account owner role ID set: " + CONFIG.discord.accountOwnerRoleId);
         }
         DiscordClient discordClient = buildProxiedClient(DiscordClientBuilder.create(CONFIG.discord.token)).build();
         this.client = discordClient.gateway()
                 .setGatewayReactorResources(reactorResources -> GatewayReactorResources.builder(discordClient.getCoreResources().getReactorResources()).build())
-                .setEnabledIntents((IntentSet.of(Intent.MESSAGE_CONTENT, Intent.GUILD_MESSAGES)))
+                .setEnabledIntents((IntentSet.of(Intent.MESSAGE_CONTENT, Intent.GUILD_MESSAGES, Intent.DIRECT_MESSAGES)))
                 .setInitialPresence(shardInfo -> disconnectedPresence)
                 .login()
                 .block();
@@ -173,7 +175,10 @@ public class DiscordBot {
             }
             try {
                 final String inputMessage = message.substring(1);
-                DISCORD_LOG.info(event.getMember().map(User::getTag).orElse("unknown user") + " (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
+                if (!CONFIG.discord.accountOwnerRoleId.isEmpty())
+                    DISCORD_LOG.info(event.getMember().map(User::getTag).orElse("unknown user") + " (" + event.getMember().get().getId().asString() +") executed discord command: {}", inputMessage);
+                else
+                    DISCORD_LOG.info(event.getMessage().getAuthor().get().getUsername() + " executed discord command: {}", inputMessage);
                 final CommandContext context = DiscordCommandContext.create(inputMessage, event, mainRestChannel);
                 COMMAND_MANAGER.execute(context);
                 final MultipartRequest<MessageCreateRequest> request = commandEmbedOutputToMessage(context);

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -142,7 +142,7 @@ public class DiscordBot {
             if (CONFIG.discord.channelId.equals(CONFIG.discord.chatRelay.channelId)) throw new RuntimeException("Discord channel id and chat relay channel id cannot be the same");
         }
         if (CONFIG.discord.accountOwnerRoleId.isEmpty()) 
-            DISCORD_LOG.error("Discord account owner role id is not set. Bot can be controlled by anyone.");
+            DISCORD_LOG.error("Discord account owner role id is not set. Bot can be controlled by anyone");
         else {
             try {
                 Snowflake.of(CONFIG.discord.accountOwnerRoleId);
@@ -153,7 +153,7 @@ public class DiscordBot {
         DiscordClient discordClient = buildProxiedClient(DiscordClientBuilder.create(CONFIG.discord.token)).build();
         this.client = discordClient.gateway()
                 .setGatewayReactorResources(reactorResources -> GatewayReactorResources.builder(discordClient.getCoreResources().getReactorResources()).build())
-                .setEnabledIntents((IntentSet.of(Intent.MESSAGE_CONTENT, Intent.GUILD_MESSAGES)))
+                .setEnabledIntents((IntentSet.of(Intent.MESSAGE_CONTENT, Intent.GUILD_MESSAGES, Intent.DIRECT_MESSAGES)))
                 .setInitialPresence(shardInfo -> disconnectedPresence)
                 .login()
                 .block();

--- a/src/main/java/com/zenith/discord/DiscordBot.java
+++ b/src/main/java/com/zenith/discord/DiscordBot.java
@@ -161,17 +161,22 @@ public class DiscordBot {
         mainRestChannel = restClient.getChannelById(Snowflake.of(CONFIG.discord.channelId));
         relayRestChannel = restClient.getChannelById(Snowflake.of(CONFIG.discord.chatRelay.channelId));
         client.getEventDispatcher().on(MessageCreateEvent.class).subscribe(event -> {
+            DISCORD_LOG.error("GOT A MESSAGE!!!");
             if (CONFIG.discord.chatRelay.enable && !CONFIG.discord.chatRelay.channelId.isEmpty() && event.getMessage().getChannelId().equals(Snowflake.of(CONFIG.discord.chatRelay.channelId))) {
+                DISCORD_LOG.error("IM CHECKING IT NOW");
                 if (!event.getMember().get().getId().equals(this.client.getSelfId())) {
+                    DISCORD_LOG.error("AND IT PASSED ALL CHECKS!!!");
                     EVENT_BUS.postAsync(new DiscordMessageSentEvent(sanitizeRelayInputMessage(event.getMessage().getContent()), event));
                     return;
                 }
             }
             if (!event.getMessage().getChannelId().equals(Snowflake.of(CONFIG.discord.channelId))) {
+                DISCORD_LOG.error("IT WAS NOT IN THE RIGHT CHANNEL");
                 return;
             }
             final String message = event.getMessage().getContent();
             if (!message.startsWith(CONFIG.discord.prefix)) {
+                DISCORD_LOG.error("IT DID NOT HAVE THE RIGHT PREFIX");
                 return;
             }
             try {


### PR DESCRIPTION
Testing needed
Sooo not entirely sure if this breaks anything, everything seems to work fine to me.
This allows the bot to be controlled via direct messages instead of a server channel

"channelId" needs to be set to the direct message id
"accountOwnerRoleId" needs to be left blank. If in a server, the bot won't check for member roles. 
^^ should be added to docs

In DMs event `getMember` has no return so a different log message is needed