### PR TITLE
fix AutoFish hasRotation will never work if the yaw is 180.0

### DIFF
--- a/src/main/java/com/zenith/module/impl/AutoFish.java
+++ b/src/main/java/com/zenith/module/impl/AutoFish.java
@@ -120,7 +120,14 @@ public class AutoFish extends AbstractInventoryModule {
 
     private boolean hasRotation() {
         var sim = MODULE.get(PlayerSimulation.class);
-        return MathHelper.isNear(MathHelper.wrapYaw(sim.getYaw()), CONFIG.client.extra.autoFish.yaw, 0.1f)
+        return (
+                MathHelper.isNear(
+                        MathHelper.wrapYaw(
+                            sim.getYaw()
+                        ),
+                        CONFIG.client.extra.autoFish.yaw, 0.1f
+                ) ||
+                        (CONFIG.client.extra.autoFish.yaw == 180.0 && MathHelper.wrapYaw(sim.getYaw()) == -180.0))
             && MathHelper.isNear(MathHelper.wrapPitch(sim.getPitch()), CONFIG.client.extra.autoFish.pitch, 0.1f);
     }
 

--- a/src/main/java/com/zenith/module/impl/AutoFish.java
+++ b/src/main/java/com/zenith/module/impl/AutoFish.java
@@ -120,15 +120,7 @@ public class AutoFish extends AbstractInventoryModule {
 
     private boolean hasRotation() {
         var sim = MODULE.get(PlayerSimulation.class);
-        return (
-                MathHelper.isNear(
-                        MathHelper.wrapYaw(
-                            sim.getYaw()
-                        ),
-                        CONFIG.client.extra.autoFish.yaw, 0.1f
-                ) ||
-                        (CONFIG.client.extra.autoFish.yaw == 180.0 && MathHelper.wrapYaw(sim.getYaw()) == -180.0))
-            && MathHelper.isNear(MathHelper.wrapPitch(sim.getPitch()), CONFIG.client.extra.autoFish.pitch, 0.1f);
+        return MathHelper.yawIsNear(MathHelper.wrapYaw(sim.getYaw()),CONFIG.client.extra.autoFish.yaw, 0.1f ) && MathHelper.isNear(MathHelper.wrapPitch(sim.getPitch()), CONFIG.client.extra.autoFish.pitch, 0.1f);
     }
 
     private boolean isRodInHand() {

--- a/src/main/java/com/zenith/util/math/MathHelper.java
+++ b/src/main/java/com/zenith/util/math/MathHelper.java
@@ -116,6 +116,12 @@ public class MathHelper {
         return val > target - range && val < target + range;
     }
 
+    public static boolean yawIsNear(float yaw, float targetYaw, float range) {
+        float yawAbs = Math.abs(yaw);
+        float targetYawAbs = Math.abs(targetYaw);
+        return Math.abs(targetYawAbs - yawAbs) <= range || Math.abs(yawAbs - targetYawAbs) <= range;
+    }
+
     public static Vector3d calculateRayEndPos(double x, double y, double z, double yaw, double pitch, double maxDistance) {
         final Vector3d viewVec = MathHelper.calculateViewVector(yaw, pitch);
         final double targetX = x + (viewVec.getX() * maxDistance);


### PR DESCRIPTION
If the yaw is 180.0, then hasRotation will never work because `MathHelper.wrapYaw(sim.getYaw())` will never be 180.0 and only can be -180.0.