### PR TITLE
Move 2b2t Time Limit Feature to Configuration with Default Value Set to 8 Hours

### DIFF
--- a/src/main/java/com/zenith/Proxy.java
+++ b/src/main/java/com/zenith/Proxy.java
@@ -96,8 +96,6 @@ public class Proxy {
     @Getter private final AtomicBoolean loggingIn = new AtomicBoolean(false);
     @Setter @NotNull private AutoUpdater autoUpdater = NoOpAutoUpdater.INSTANCE;
     private LanBroadcaster lanBroadcaster;
-    // might move to config and make the user deal with it when it changes
-    private static final Duration twoB2tTimeLimit = Duration.ofHours(6);
     private TcpConnectionManager tcpManager;
 
     public static void main(String... args) {
@@ -172,7 +170,7 @@ public class Proxy {
             CACHE.reset(CacheResetType.FULL);
             EXECUTOR.scheduleAtFixedRate(this::serverHealthCheck, 1L, 5L, TimeUnit.MINUTES);
             EXECUTOR.scheduleAtFixedRate(this::tablistUpdate, 20L, 3L, TimeUnit.SECONDS);
-            EXECUTOR.scheduleAtFixedRate(this::twoB2tTimeLimitKickWarningTick, twoB2tTimeLimit.minusMinutes(10L).toMinutes(), 1L, TimeUnit.MINUTES);
+            EXECUTOR.scheduleAtFixedRate(this::twoB2tTimeLimitKickWarningTick, Duration.ofMinutes(CONFIG.client.extra.timeLimitWarning.timeLimit).minusMinutes(10).toMinutes(), 1L, TimeUnit.MINUTES);
             EXECUTOR.scheduleAtFixedRate(this::maxPlaytimeTick, CONFIG.client.maxPlaytimeReconnectMins, 1L, TimeUnit.MINUTES);
             EXECUTOR.schedule(this::serverConnectionTest, 10L, TimeUnit.SECONDS);
             if (CONFIG.server.enabled && CONFIG.server.ping.favicon)
@@ -641,15 +639,16 @@ public class Proxy {
 
     public void twoB2tTimeLimitKickWarningTick() {
         try {
-            if (this.isPrio() // Prio players don't get kicked
+            if (!CONFIG.client.extra.timeLimitWarning.enabled // Time limit warning disabled
+                ||  this.isPrio() // Prio players don't get kicked
                 || !this.hasActivePlayer() // If no player is connected, nobody to warn
-                || !isOnlineOn2b2tForAtLeastDuration(twoB2tTimeLimit.minusMinutes(10L))
+                || !isOnlineOn2b2tForAtLeastDuration(Duration.ofMinutes(CONFIG.client.extra.timeLimitWarning.timeLimit).minusMinutes(10))
             ) return;
             final ServerSession playerConnection = this.currentPlayer.get();
-            final Duration durationUntilKick = twoB2tTimeLimit.minus(Duration.ofSeconds(Proxy.getInstance().getOnlineTimeSecondsWithQueueSkip()));
+            final Duration durationUntilKick = Duration.ofMinutes(CONFIG.client.extra.timeLimitWarning.timeLimit).minus(Duration.ofSeconds(Proxy.getInstance().getOnlineTimeSecondsWithQueueSkip()));
             if (durationUntilKick.isNegative()) return; // sanity check just in case 2b's plugin changes
             var actionBarPacket = new ClientboundSetActionBarTextPacket(
-                ComponentSerializer.minimessage((durationUntilKick.toMinutes() <= 3 ? "<red>" : "<blue>") + twoB2tTimeLimit.toHours() + "hr kick in: " + durationUntilKick.toMinutes() + "m"));
+                ComponentSerializer.minimessage((durationUntilKick.toMinutes() <= 3 ? "<red>" : "<blue>") + Duration.ofMinutes(CONFIG.client.extra.timeLimitWarning.timeLimit).toHours() + "hr kick in: " + durationUntilKick.toMinutes() + "m"));
             playerConnection.sendAsync(actionBarPacket);
             // each packet will reset text render timer for 3 seconds
             for (int i = 1; i <= 7; i++) { // render the text for about 10 seconds total

--- a/src/main/java/com/zenith/command/CommandManager.java
+++ b/src/main/java/com/zenith/command/CommandManager.java
@@ -69,6 +69,7 @@ public class CommandManager {
         new PrioCommand(),
         new QueueStatusCommand(),
         new QueueWarningCommand(),
+        new TimeLimitWarningCommand(),
         new RaycastCommand(),
         new ReconnectCommand(),
         new ReleaseChannelCommand(),

--- a/src/main/java/com/zenith/command/impl/TimeLimitWarningCommand.java
+++ b/src/main/java/com/zenith/command/impl/TimeLimitWarningCommand.java
@@ -1,0 +1,57 @@
+package com.zenith.command.impl;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.zenith.command.Command;
+import com.zenith.command.CommandUsage;
+import com.zenith.command.brigadier.CommandCategory;
+import com.zenith.command.brigadier.CommandContext;
+import com.zenith.discord.Embed;
+
+import static com.mojang.brigadier.arguments.IntegerArgumentType.getInteger;
+import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
+import static com.zenith.Shared.CONFIG;
+import static com.zenith.command.brigadier.ToggleArgumentType.getToggle;
+import static com.zenith.command.brigadier.ToggleArgumentType.toggle;
+import static java.util.Arrays.asList;
+
+public class TimeLimitWarningCommand extends Command {
+    @Override
+    public CommandUsage commandUsage() {
+        return CommandUsage.args(
+            "timeLimitWarning",
+            CommandCategory.INFO,
+            """
+            Configure warnings sent when 2b2t time limit is reached.
+            """,
+            asList(
+                "on/off",
+                "timeLimit <minutes>"
+            )
+        );
+    }
+
+    @Override
+    public LiteralArgumentBuilder<CommandContext> register() {
+        return command("timeLimit")
+            .then(argument("toggle", toggle()).executes(c -> {
+                CONFIG.client.extra.timeLimitWarning.enabled = getToggle(c, "toggle");
+                c.getSource().getEmbed()
+                    .title("Time Limit Warning " + toggleStrCaps(CONFIG.client.extra.timeLimitWarning.enabled));
+                return OK;
+            }))
+            .then(literal("timeLimit").then(argument("minutes", integer(1, 1000)).executes(c -> {
+                int minutes = getInteger(c, "minutes");
+                CONFIG.client.extra.timeLimitWarning.timeLimit = minutes;
+                c.getSource().getEmbed().title("Time Limit set to " + minutes + " minutes");
+                return OK;
+            })));
+    }
+
+    @Override
+    public void postPopulate(final Embed builder) {
+        builder
+            .addField("Time Limit Warning", toggleStr(CONFIG.client.extra.timeLimitWarning.enabled), false)
+            .description("**Time Limit:** " + CONFIG.client.extra.timeLimitWarning.timeLimit + " minutes")
+            .primaryColor();
+    }
+}

--- a/src/main/java/com/zenith/command/impl/TimeLimitWarningCommand.java
+++ b/src/main/java/com/zenith/command/impl/TimeLimitWarningCommand.java
@@ -32,7 +32,7 @@ public class TimeLimitWarningCommand extends Command {
 
     @Override
     public LiteralArgumentBuilder<CommandContext> register() {
-        return command("timeLimit")
+        return command("timeLimitWarning")
             .then(argument("toggle", toggle()).executes(c -> {
                 CONFIG.client.extra.timeLimitWarning.enabled = getToggle(c, "toggle");
                 c.getSource().getEmbed()

--- a/src/main/java/com/zenith/util/Config.java
+++ b/src/main/java/com/zenith/util/Config.java
@@ -124,6 +124,7 @@ public final class Config {
             public final AutoArmor autoArmor = new AutoArmor();
             public final AutoMend autoMend = new AutoMend();
             public final QueueWarning queueWarning = new QueueWarning();
+            public final TimeLimitWarning timeLimitWarning = new TimeLimitWarning();
             public final Wander wander = new Wander();
             public final Click click = new Click();
 
@@ -158,6 +159,11 @@ public final class Config {
                 public boolean enabled = true;
                 public IntArraySet warningPositions = new IntArraySet(asList(1, 2, 3, 10));
                 public IntArraySet mentionPositions = new IntArraySet();
+            }
+
+            public static final class TimeLimitWarning {
+                public boolean enabled = true;
+                public int timeLimit = 8 * 60; // 8 hours
             }
 
             public static class AutoMend {


### PR DESCRIPTION
This PR introduces the following changes to the ZenithProxy project:

- **Feature Update:** The 2b2t time limit feature is now configurable through the configuration file.
- **Default Value:** The default time limit is set to 8 hours.
- **New Command:** Added a new command `timeLimitWarning` to allow users to enable/disable the warning and set the time limit dynamically.

**Details:**
- The hardcoded `twoB2tTimeLimit` value has been removed from `Proxy.java` and replaced with a configurable value from `CONFIG.client.extra.timeLimitWarning.timeLimit`.
- The time limit warning logic has been updated to use the new configurable value.
- Introduced a new command `TimeLimitWarningCommand` to manage the time limit warning settings.
- Updated the configuration class to include the new `TimeLimitWarning` class with default values.

This update ensures that users can easily adjust the 2b2t time limit as per their requirements without modifying the source code. The default time limit is now set to 8 hours, reflecting the recent update.