### PR TITLE
add a setting for parsing EssentialsChat-like chat formatting

### DIFF
--- a/src/main/java/com/zenith/cache/data/tab/TabListCache.java
+++ b/src/main/java/com/zenith/cache/data/tab/TabListCache.java
@@ -74,6 +74,10 @@ public class TabListCache implements CachedData {
         return this.tablist.values().stream().filter(v -> v.getName().equals(username)).findFirst();
     }
 
+    public Optional<PlayerListEntry> getFromDisplayName(final String username) {
+        return this.tablist.values().stream().filter(v -> v.getDisplayName().equals(username)).findFirst();
+    }
+
     public Collection<PlayerListEntry> getEntries() {
         return this.tablist.values();
     }

--- a/src/main/java/com/zenith/command/impl/ChatRelayCommand.java
+++ b/src/main/java/com/zenith/command/impl/ChatRelayCommand.java
@@ -28,7 +28,8 @@ public class ChatRelayCommand extends Command {
             
             The ChatRelay is a live feed of chat messages and/or connection messages from the server to a Discord channel.
             
-            Mentions can be configured when a whisper is received or your name is seen in chat.
+            Mentions can be configured when a whisper is received or your name is seen in chat. 
+            (enable resolved only if someone is abusing custom nicknames to spam you with pings)
             
             Messages typed in the ChatRelay discord channel will be sent as chat messages in-game
             Discord message replies will be sent as whispers in-game
@@ -44,6 +45,7 @@ public class ChatRelayCommand extends Command {
                 "whisperMentions on/off",
                 "nameMentions on/off",
                 "mentionsWhileConnected on/off",
+                "mentionResolvedOnly on/off",
                 "ignoreQueue on/off",
                 "sendMessages on/off"
             )
@@ -167,6 +169,13 @@ public class ChatRelayCommand extends Command {
                             CONFIG.discord.chatRelay.sendMessages = getToggle(c, "toggle");
                             c.getSource().getEmbed()
                                 .title("Send Messages " + toggleStrCaps(CONFIG.discord.chatRelay.sendMessages));
+                            return OK;
+                      })))
+            .then(literal("mentionResolvedOnly")
+                      .then(argument("toggle", toggle()).executes(c -> {
+                            CONFIG.discord.chatRelay.mentionResolvedOnly = getToggle(c, "toggle");
+                            c.getSource().getEmbed()
+                                .title("Send Messages " + toggleStrCaps(CONFIG.discord.chatRelay.mentionResolvedOnly));
                             return OK;
                       })));
     }

--- a/src/main/java/com/zenith/command/impl/ExtraChatCommand.java
+++ b/src/main/java/com/zenith/command/impl/ExtraChatCommand.java
@@ -18,7 +18,8 @@ public class ExtraChatCommand extends Command {
             .name("extraChat")
             .category(CommandCategory.MODULE)
             .description("""
-             Hide certain types of messages in-game or in the terminal chat log.
+             Hide certain types of messages in-game or in the terminal chat log,
+             and modify how chat messages are parsed
              """)
             .usageLines(
                 "on/off",
@@ -26,7 +27,8 @@ public class ExtraChatCommand extends Command {
                 "hideWhispers on/off",
                 "hideDeathMessages on/off",
                 "showConnectionMessages on/off",
-                "logChatMessages on/off"
+                "logChatMessages on/off",
+                "essentialsFormatting on/off"
             )
             .build();
     }
@@ -73,6 +75,13 @@ public class ExtraChatCommand extends Command {
                             c.getSource().getEmbed()
                                 .title("Log Chat Messages " + toggleStrCaps(CONFIG.client.extra.logChatMessages));
                             return OK;
+                        })))
+            .then(literal("essentialsFormatting")
+                      .then(argument("toggle", toggle()).executes(c -> {
+                            CONFIG.client.extra.chat.essentialsFormatting = getToggle(c, "toggle");
+                            c.getSource().getEmbed()
+                                .title("Parse Default EssentialsChat Format " + toggleStrCaps(CONFIG.client.extra.chat.essentialsFormatting));
+                            return OK;
                         })));
     }
 
@@ -86,6 +95,7 @@ public class ExtraChatCommand extends Command {
             .addField("Hide death Messages", toggleStr(CONFIG.client.extra.chat.hideDeathMessages), false)
             .addField("Show Connection Messages", toggleStr(CONFIG.client.extra.chat.showConnectionMessages), false)
             .addField("Log Chat Messages", toggleStr(CONFIG.client.extra.logChatMessages), false)
+            .addField("Parse Default EssentialsChat Format", toggleStr(CONFIG.client.extra.chat.essentialsFormatting), false)
             .primaryColor();
     }
 }

--- a/src/main/java/com/zenith/discord/NotificationEventListener.java
+++ b/src/main/java/com/zenith/discord/NotificationEventListener.java
@@ -603,17 +603,42 @@ public class NotificationEventListener {
     }
 
     private void handleSystemChatEvent(SystemChatEvent event) {
-        if (!CONFIG.discord.chatRelay.serverMessages) return;
+        if (event.isUnresolvedPublicChat())
+        {
+            if (!CONFIG.discord.chatRelay.publicChats) return;
+        } else if (event.isUnresolvedWhisper())
+        {
+            if (!CONFIG.discord.chatRelay.whispers) return;
+        }
+        else if (!CONFIG.discord.chatRelay.serverMessages) return;
+
         if (!CONFIG.discord.chatRelay.enable || CONFIG.discord.chatRelay.channelId.isEmpty()) return;
         if (CONFIG.discord.chatRelay.ignoreQueue && Proxy.getInstance().isInQueue()) return;
         try {
             String message = event.message();
             final String avatarURL = Proxy.getInstance().isOn2b2t() ? Proxy.getInstance().getPlayerHeadURL("Hausemaster").toString() : null;
+
+            var color = Color.MOON_YELLOW;
+            String ping = "";
+
+            if (event.isUnresolvedPublicChat()) color = Color.BLACK;
+            if (event.isUnresolvedWhisper()) color = Color.MAGENTA;
+
+            if (event.isUnresolvedIncomingWhisper() && CONFIG.discord.chatRelay.mentionRoleOnWhisper 
+                && !CONFIG.discord.chatRelay.mentionResolvedOnly)
+            {
+                if (CONFIG.discord.chatRelay.mentionWhileConnected || isNull(Proxy.getInstance().getCurrentPlayer().get()))
+                {
+                    ping = notificationMention();
+                }
+            }
+
             var embed = Embed.builder()
                 .description(escape(message))
                 .footer("\u200b", avatarURL)
-                .color(Color.MOON_YELLOW);
-            sendRelayEmbedMessage(embed);
+                .color(color);
+            sendRelayEmbedMessage(ping, embed);
+
         } catch (final Throwable e) {
             DISCORD_LOG.error("Error processing SystemChatEvent", e);
         }

--- a/src/main/java/com/zenith/event/chat/SystemChatEvent.java
+++ b/src/main/java/com/zenith/event/chat/SystemChatEvent.java
@@ -4,5 +4,8 @@ import net.kyori.adventure.text.Component;
 
 public record SystemChatEvent(
     Component component,
-    String message
+    String message,
+    boolean isUnresolvedPublicChat,
+    boolean isUnresolvedWhisper,
+    boolean isUnresolvedIncomingWhisper
 ) { }

--- a/src/main/java/com/zenith/network/client/handler/incoming/SystemChatHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/SystemChatHandler.java
@@ -31,6 +31,9 @@ public class SystemChatHandler implements ClientEventLoopPacketHandler<Clientbou
     @Override
     public boolean applyAsync(@NonNull ClientboundSystemChatPacket packet, @NonNull ClientSession session) {
         try {
+
+            final boolean essentialsChat = CONFIG.client.extra.chat.essentialsFormatting;
+
             if (CONFIG.client.extra.logChatMessages) {
                 var component = packet.getContent();
                 if (Proxy.getInstance().isInQueue()) {
@@ -50,20 +53,83 @@ public class SystemChatHandler implements ClientEventLoopPacketHandler<Clientbou
                 deathMessage = parseDeathMessage2b2t(component, deathMessage, messageString);
             if (messageString.startsWith("<")) {
                 senderName = extractSenderNameNormalChat(messageString);
-            } else if (deathMessage.isEmpty()) {
-                final String[] split = messageString.split(" ");
-                if (split.length > 2) {
-                    if (split[1].startsWith("whispers")) {
-                        senderName = extractSenderNameReceivedWhisper(split);
+            } 
+            else if (deathMessage.isEmpty()) {
+                if (essentialsChat && messageString.startsWith("["))
+                {
+                    // [$senderName -> me] $messageText
+                    // [me -> $whisperTarget] $messageText
+                    final String inner = extractBracketContents(messageString, 0);
+                    if (inner.endsWith(" -> me")) 
+                    {
+                        senderName = inner.substring(0, inner.length() - 6);
                         whisperTarget = CONFIG.authentication.username;
-                    } else if (messageString.startsWith("to ")) {
+                    }
+                    else if (inner.startsWith("me -> "))
+                    {
                         senderName = CONFIG.authentication.username;
-                        whisperTarget = extractReceiverNameSentWhisper(split);
+                        whisperTarget = inner.substring(6);
+                    }
+                }
+                else
+                { 
+                    final String[] split = messageString.split(" ");
+                    if (split.length > 2) {
+                        if (split[1].startsWith("whispers")) {
+                            senderName = extractSenderNameReceivedWhisper(split);
+                            whisperTarget = CONFIG.authentication.username;
+                        } else if (messageString.startsWith("to ")) {
+                            senderName = CONFIG.authentication.username;
+                            whisperTarget = extractReceiverNameSentWhisper(split);
+                        }
                     }
                 }
             }
+
+            final String decoratedSenderName = senderName;
+            final String decoratedWhisperTarget = whisperTarget;
+
+            // Try to strip any ranks or other decoration from the names
+            if (essentialsChat && senderName != null)
+            {
+                final String[] split = senderName.split(" ");
+                senderName = split[split.length - 1];
+            }
+            if (essentialsChat && whisperTarget != null)
+            {
+                final String[] split = whisperTarget.split(" ");
+                whisperTarget = split[split.length - 1];
+            }
+
             var sender = Optional.ofNullable(senderName).flatMap(t -> CACHE.getTabListCache().getFromName(t));
             var playerWhisperTarget = Optional.ofNullable(whisperTarget).flatMap(t -> CACHE.getTabListCache().getFromName(t));
+
+            // The above attempt at getting the player name failed. Try to match the full display name against a display name in tab instead.
+            if (sender.isEmpty() && decoratedSenderName != null && essentialsChat)
+            {
+                sender = Optional.ofNullable(decoratedSenderName).flatMap(t -> CACHE.getTabListCache().getFromDisplayName(t));
+            }
+            if (playerWhisperTarget.isEmpty() && decoratedWhisperTarget != null && essentialsChat)
+            {
+                playerWhisperTarget = Optional.ofNullable(decoratedWhisperTarget).flatMap(t -> CACHE.getTabListCache().getFromDisplayName(t));
+            }
+
+            // Try to match the clipped display name against a display name in tab too.
+            if (sender.isEmpty() && senderName != null && essentialsChat)
+            {
+                sender = Optional.ofNullable(senderName).flatMap(t -> CACHE.getTabListCache().getFromDisplayName(t));
+            }
+            if (playerWhisperTarget.isEmpty() && whisperTarget != null && essentialsChat)
+            {
+                playerWhisperTarget = Optional.ofNullable(whisperTarget).flatMap(t -> CACHE.getTabListCache().getFromDisplayName(t));
+            }
+
+            // Treat unresolved outgoing whispers as server messages and not public chat, to match what happens with incoming ones.
+            if (playerWhisperTarget.isEmpty() && decoratedWhisperTarget != null && essentialsChat) 
+            {
+                    sender = Optional.empty();
+            }
+
             if (Proxy.getInstance().isOn2b2t()
                 && "Reconnecting to server 2b2t.".equals(messageString)
                 && NamedTextColor.GOLD.equals(component.style().color())) {
@@ -112,5 +178,19 @@ public class SystemChatHandler implements ClientEventLoopPacketHandler<Clientbou
 
     private String extractReceiverNameSentWhisper(final String[] messageSplit) {
         return messageSplit[1].replace(":", "");
+    }
+
+    private String extractBracketContents(final String _str, Integer index) {
+        final char[] str = _str.toCharArray();
+        Integer level = 0;
+        for (Integer i = index; i < _str.length(); i++)
+        {
+            if (str[i] == '[') level++;
+            if (str[i] == ']' && --level == 0)
+            {
+                return _str.substring(index + 1, i);
+            }
+        }
+        return "";
     }
 }

--- a/src/main/java/com/zenith/network/client/handler/incoming/SystemChatHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/SystemChatHandler.java
@@ -124,10 +124,15 @@ public class SystemChatHandler implements ClientEventLoopPacketHandler<Clientbou
                 playerWhisperTarget = Optional.ofNullable(whisperTarget).flatMap(t -> CACHE.getTabListCache().getFromDisplayName(t));
             }
 
-            // Treat unresolved outgoing whispers as server messages and not public chat, to match what happens with incoming ones.
-            if (playerWhisperTarget.isEmpty() && decoratedWhisperTarget != null && essentialsChat) 
+            // Mark false-positive system messages caused by unresolved names, so chatRelay still handles them correctly.
+            final boolean isUnresolvedIncomingWhisper = sender.isEmpty() && playerWhisperTarget.isPresent() 
+                && playerWhisperTarget.get().getName().equalsIgnoreCase(CONFIG.authentication.username);
+            final boolean isUnresolvedWhisper = whisperTarget != null && (playerWhisperTarget.isEmpty() || sender.isEmpty());
+            final boolean isUnresolvedPublicChat = whisperTarget == null && senderName != null && sender.isEmpty();
+
+            if (isUnresolvedWhisper) 
             {
-                    sender = Optional.empty();
+                sender = Optional.empty();
             }
 
             if (Proxy.getInstance().isOn2b2t()
@@ -145,7 +150,7 @@ public class SystemChatHandler implements ClientEventLoopPacketHandler<Clientbou
             } else if (sender.isEmpty() && deathMessage.isPresent() && playerWhisperTarget.isEmpty()) {
                 EVENT_BUS.postAsync(new DeathMessageChatEvent(deathMessage.get(), component, messageString));
             } else {
-                EVENT_BUS.postAsync(new SystemChatEvent(component, messageString));
+                EVENT_BUS.postAsync(new SystemChatEvent(component, messageString, isUnresolvedPublicChat, isUnresolvedWhisper, isUnresolvedIncomingWhisper));
             }
         } catch (final Exception e) {
             CLIENT_LOG.error("Caught exception in ChatHandler. Packet: {}", packet, e);

--- a/src/main/java/com/zenith/util/config/Config.java
+++ b/src/main/java/com/zenith/util/config/Config.java
@@ -748,6 +748,7 @@ public final class Config {
             public boolean mentionRoleOnWhisper = true;
             public boolean mentionRoleOnNameMention = true;
             public boolean mentionWhileConnected = false;
+            public boolean mentionResolvedOnly = false;
             public boolean connectionMessages = false;
             public boolean publicChats = true;
             public boolean whispers = true;

--- a/src/main/java/com/zenith/util/config/Config.java
+++ b/src/main/java/com/zenith/util/config/Config.java
@@ -272,6 +272,7 @@ public final class Config {
                 public boolean hideWhispers = false;
                 public boolean hideDeathMessages = false;
                 public boolean showConnectionMessages = false;
+                public boolean essentialsFormatting = false;
             }
 
             public static final class AutoTotem {


### PR DESCRIPTION
Adds a new setting `extraChat essentialsFormat`, which causes whispers formatted as  `[abc -> me] message` and  `[me -> abc] message` to be parsed, and tries to account for usernames having decorative prefixes like `[admin] user` in chat. 

a very large fraction of servers with non-vanilla chat formatting use this style instead, so having bulilt-in support for it in ZenithProxy would be very useful. The setting is not enabled by default since it is unnecessary on 2b2t.

The setting `chatRelay mentionResolvedOnly` is added to avoid a vector for ping spam which otherwise could only be ignored by disabling whisper mentions entirely.