### PR TITLE
Update AutoOmen: Add ignoreRaidStatus Option

### DIFF
--- a/src/main/java/com/zenith/command/impl/AutoOmenCommand.java
+++ b/src/main/java/com/zenith/command/impl/AutoOmenCommand.java
@@ -21,11 +21,12 @@ public class AutoOmenCommand extends Command {
             .category(CommandCategory.MODULE)
             .description("""
                 Automatically drinks Bad Omen potions in the inventory.
-                
+
                 Useful for raid farms on MC 1.21+ servers.
                 """)
             .usageLines(
-                "on/off"
+                "on/off",
+                "ignoreRaidStatus on/off"
             )
             .build();
     }
@@ -39,7 +40,15 @@ public class AutoOmenCommand extends Command {
                     .title("AutoOmen " + toggleStrCaps(CONFIG.client.extra.autoOmen.enabled));
                 MODULE.get(AutoOmen.class).syncEnabledFromConfig();
                 return OK;
-            }));
+            }))
+            .then(literal("ignoreRaidStatus")
+                .then(argument("toggle", toggle()).executes(c -> {
+                    CONFIG.client.extra.autoOmen.ignoreRaidStatus = getToggle(c, "toggle");
+                    c.getSource().getEmbed()
+                        .title("AutoOmen Ignore Raid Status " + toggleStrCaps(CONFIG.client.extra.autoOmen.ignoreRaidStatus))
+                        .description("When enabled, AutoOmen will use ominous bottles regardless of raid status or existing omen effects.");
+                    return OK;
+                })));
     }
 
     @Override

--- a/src/main/java/com/zenith/command/impl/AutoOmenCommand.java
+++ b/src/main/java/com/zenith/command/impl/AutoOmenCommand.java
@@ -26,7 +26,8 @@ public class AutoOmenCommand extends Command {
                 """)
             .usageLines(
                 "on/off",
-                "ignoreRaidStatus on/off"
+                "whileRaidActive on/off",
+                "whileOmenActive on/off"
             )
             .build();
     }
@@ -39,22 +40,25 @@ public class AutoOmenCommand extends Command {
                 c.getSource().getEmbed()
                     .title("AutoOmen " + toggleStrCaps(CONFIG.client.extra.autoOmen.enabled));
                 MODULE.get(AutoOmen.class).syncEnabledFromConfig();
-                return OK;
             }))
-            .then(literal("ignoreRaidStatus")
-                .then(argument("toggle", toggle()).executes(c -> {
-                    CONFIG.client.extra.autoOmen.ignoreRaidStatus = getToggle(c, "toggle");
-                    c.getSource().getEmbed()
-                        .title("AutoOmen Ignore Raid Status " + toggleStrCaps(CONFIG.client.extra.autoOmen.ignoreRaidStatus))
-                        .description("When enabled, AutoOmen will use ominous bottles regardless of raid status or existing omen effects.");
-                    return OK;
-                })));
+            .then(literal("whileRaidActive").then(argument("toggle", toggle()).executes(c -> {
+                CONFIG.client.extra.autoOmen.whileRaidActive = getToggle(c, "toggle");
+                c.getSource().getEmbed()
+                    .title("AutoOmen While Raid Active " + toggleStrCaps(CONFIG.client.extra.autoOmen.whileRaidActive));
+            })))
+            .then(literal("whileOmenActive").then(argument("toggle", toggle()).executes(c -> {;
+                CONFIG.client.extra.autoOmen.whileOmenActive = getToggle(c, "toggle");
+                c.getSource().getEmbed()
+                    .title("AutoOmen While Omen Active " + toggleStrCaps(CONFIG.client.extra.autoOmen.whileOmenActive));
+            })));
     }
 
     @Override
     public void defaultEmbed(Embed embed) {
         embed
-            .addField("AutoOmen", toggleStr(CONFIG.client.extra.autoOmen.enabled), false)
+            .addField("AutoOmen", toggleStr(CONFIG.client.extra.autoOmen.enabled))
+            .addField("While Raid Active", toggleStr(CONFIG.client.extra.autoOmen.whileRaidActive))
+            .addField("While Omen Active", toggleStr(CONFIG.client.extra.autoOmen.whileOmenActive))
             .primaryColor();
     }
 }

--- a/src/main/java/com/zenith/module/impl/AutoOmen.java
+++ b/src/main/java/com/zenith/module/impl/AutoOmen.java
@@ -47,12 +47,17 @@ public class AutoOmen extends AbstractInventoryModule {
     }
 
     public void handleClientTick(final ClientBotTick e) {
-        if (CACHE.getPlayerCache().getThePlayer().isAlive()
-            && !isRaidActive()
-            && !hasOmenEffect()
+        boolean shouldUseOmen = CACHE.getPlayerCache().getThePlayer().isAlive()
             && CACHE.getPlayerCache().getGameMode() != GameMode.CREATIVE
             && CACHE.getPlayerCache().getGameMode() != GameMode.SPECTATOR
-            && Proxy.getInstance().getOnlineTimeSeconds() > 1) {
+            && Proxy.getInstance().getOnlineTimeSeconds() > 1;
+
+        // Check raid status and omen effect only if ignoreRaidStatus is false
+        if (shouldUseOmen && !CONFIG.client.extra.autoOmen.ignoreRaidStatus) {
+            shouldUseOmen = !isRaidActive() && !hasOmenEffect();
+        }
+
+        if (shouldUseOmen) {
             if (delay > 0) {
                 delay--;
                 if (isEating) {

--- a/src/main/java/com/zenith/module/impl/AutoOmen.java
+++ b/src/main/java/com/zenith/module/impl/AutoOmen.java
@@ -47,17 +47,12 @@ public class AutoOmen extends AbstractInventoryModule {
     }
 
     public void handleClientTick(final ClientBotTick e) {
-        boolean shouldUseOmen = CACHE.getPlayerCache().getThePlayer().isAlive()
+        if (CACHE.getPlayerCache().getThePlayer().isAlive()
+            && (CONFIG.client.extra.autoOmen.whileRaidActive || !isRaidActive())
+            && (CONFIG.client.extra.autoOmen.whileOmenActive || !hasOmenEffect())
             && CACHE.getPlayerCache().getGameMode() != GameMode.CREATIVE
             && CACHE.getPlayerCache().getGameMode() != GameMode.SPECTATOR
-            && Proxy.getInstance().getOnlineTimeSeconds() > 1;
-
-        // Check raid status and omen effect only if ignoreRaidStatus is false
-        if (shouldUseOmen && !CONFIG.client.extra.autoOmen.ignoreRaidStatus) {
-            shouldUseOmen = !isRaidActive() && !hasOmenEffect();
-        }
-
-        if (shouldUseOmen) {
+            && Proxy.getInstance().getOnlineTimeSeconds() > 1) {
             if (delay > 0) {
                 delay--;
                 if (isEating) {

--- a/src/main/java/com/zenith/util/config/Config.java
+++ b/src/main/java/com/zenith/util/config/Config.java
@@ -356,7 +356,8 @@ public final class Config {
 
             public static final class AutoOmen {
                 public boolean enabled = false;
-                public boolean ignoreRaidStatus = false;
+                public boolean whileRaidActive = false;
+                public boolean whileOmenActive = false;
             }
 
             public static final class Stalk {

--- a/src/main/java/com/zenith/util/config/Config.java
+++ b/src/main/java/com/zenith/util/config/Config.java
@@ -356,6 +356,7 @@ public final class Config {
 
             public static final class AutoOmen {
                 public boolean enabled = false;
+                public boolean ignoreRaidStatus = false;
             }
 
             public static final class Stalk {


### PR DESCRIPTION
This PR adds a new option ignoreRaidStatus to AutoOmen.

In high-efficiency raid farming setups, players often need to trigger omen migration more frequently by using potions. Currently, the system may skip triggers if a raid is already active, which interrupts the farming loop.

With ignoreRaidStatus enabled, AutoOmen will bypass the raid status check and allow continuous triggering, making it easier to synchronize with redstone-controlled timing mechanisms for optimal farm performance.

This change enables smoother and more reliable raid farming automation.