### PR TITLE
only disable bot if ZENITH_DISCORD_DISABLED is true, yes or 1

### DIFF
--- a/src/launcher/setup.py
+++ b/src/launcher/setup.py
@@ -341,7 +341,7 @@ def setup_unattended(config):
         discord_disabled_env = os.getenv("ZENITH_DISCORD_DISABLED")
 
         # idk how exactly you plan to do anything after this but ok
-        discord_bot = not (discord_disabled_env and discord_disabled_env.lower() in ['true', 'yes', '1'])
+        discord_bot = discord_disabled_env is None or discord_disabled_env.lower() in ['false', '0', 'no']
         if discord_bot:
             discord_bot_token = os.getenv("ZENITH_DISCORD_TOKEN")
             if discord_bot_token is None:

--- a/src/launcher/setup.py
+++ b/src/launcher/setup.py
@@ -338,11 +338,11 @@ def setup_unattended(config):
         # some env vars have default values
         port = os.getenv("ZENITH_PORT", 25565)
         ip = os.getenv("ZENITH_IP", "localhost")
-        if os.getenv("ZENITH_DISCORD_DISABLED") is not None:
-            # idk how exactly you plan to do anything after this but ok
-            discord_bot = False
-        else:
-            discord_bot = True
+        discord_disabled_env = os.getenv("ZENITH_DISCORD_DISABLED")
+
+        # idk how exactly you plan to do anything after this but ok
+        discord_bot = not (discord_disabled_env and discord_disabled_env.lower() in ['true', 'yes', '1'])
+        if discord_bot:
             discord_bot_token = os.getenv("ZENITH_DISCORD_TOKEN")
             if discord_bot_token is None:
                 critical_error("ZENITH_DISCORD_TOKEN env variable must be set in unattended mode")


### PR DESCRIPTION
previously, any value even 'false' would disable the bot. 
noticeable by simply uncommenting the flag [here](https://github.com/rfresh2/ZenithProxyDocker/blob/mainline/docker-compose.yml)