### PR TITLE
Force sending resource bundle loaded status and modify JLine prefix

### DIFF
--- a/src/main/java/com/zenith/network/client/handler/incoming/ResourcePackPushHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/ResourcePackPushHandler.java
@@ -1,24 +1,26 @@
 package com.zenith.network.client.handler.incoming;
 
-import com.zenith.Proxy;
 import com.zenith.cache.data.config.ResourcePack;
 import com.zenith.network.client.ClientSession;
 import com.zenith.network.codec.PacketHandler;
 import org.geysermc.mcprotocollib.protocol.data.game.ResourcePackStatus;
 import org.geysermc.mcprotocollib.protocol.packet.common.clientbound.ClientboundResourcePackPushPacket;
 import org.geysermc.mcprotocollib.protocol.packet.common.serverbound.ServerboundResourcePackPacket;
+import org.jspecify.annotations.NonNull;
 
 import static com.zenith.Globals.CACHE;
+import static com.zenith.Globals.CLIENT_LOG; 
 
 public class ResourcePackPushHandler implements PacketHandler<ClientboundResourcePackPushPacket, ClientSession> {
     public static final ResourcePackPushHandler INSTANCE = new ResourcePackPushHandler();
+
     @Override
-    public ClientboundResourcePackPushPacket apply(final ClientboundResourcePackPushPacket packet, final ClientSession session) {
+    public ClientboundResourcePackPushPacket apply(@NonNull final ClientboundResourcePackPushPacket packet, @NonNull final ClientSession session) {
         CACHE.getConfigurationCache().getResourcePacks().put(packet.getId(), new ResourcePack(packet.getId(), packet.getUrl(), packet.getHash(), packet.isRequired(), packet.getPrompt()));
-        if (Proxy.getInstance().hasActivePlayer()) return packet;
-        else {
-            session.sendAsync(new ServerboundResourcePackPacket(packet.getId(), ResourcePackStatus.SUCCESSFULLY_LOADED));
-            return null;
-        }
+        session.sendAsync(new ServerboundResourcePackPacket(packet.getId(), ResourcePackStatus.ACCEPTED));
+        CLIENT_LOG.debug("Spoofed resource pack status to ACCEPTED for: {}", packet.getId());
+        session.sendAsync(new ServerboundResourcePackPacket(packet.getId(), ResourcePackStatus.SUCCESSFULLY_LOADED));
+        CLIENT_LOG.debug("Spoofed resource pack status to SUCCESSFULLY_LOADED for: {}", packet.getId());
+        return null; 
     }
 }

--- a/src/main/java/com/zenith/terminal/TerminalManager.java
+++ b/src/main/java/com/zenith/terminal/TerminalManager.java
@@ -34,6 +34,7 @@ public class TerminalManager {
             TERMINAL_LOG.info("Starting Interactive Terminal...");
             this.lineReader = LineReaderBuilder.builder()
                 .terminal(terminal)
+                .appName("ZenithProxy")
                 .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
                 .option(LineReader.Option.CASE_INSENSITIVE, true)
                 .option(LineReader.Option.INSERT_TAB, false)


### PR DESCRIPTION
I found that sometimes the server would find that the player did not install the resource pack, so I modified the resource pack part. In addition, I added the application name in JLine