### PR TITLE
Make MIN_DIST_PATH configurable within the settings

### DIFF
--- a/src/main/java/com/zenith/command/impl/PathfinderCommand.java
+++ b/src/main/java/com/zenith/command/impl/PathfinderCommand.java
@@ -762,6 +762,13 @@ public class PathfinderCommand extends Command {
                     .addField("Failed Path Search Cooldown", CONFIG.client.extra.pathfinder.failedPathSearchCooldownMs)
                     .primaryColor();
             })))
+            .then(literal("minDistPath").then(argument("blocks", doubleArg(0.0, 1000.0)).executes(c -> {
+                CONFIG.client.extra.pathfinder.minDistPath = getDouble(c, "blocks");
+                c.getSource().getEmbed()
+                    .title("Pathfinder")
+                    .addField("Min Dist Path", CONFIG.client.extra.pathfinder.minDistPath)
+                    .primaryColor();
+            })))
             .then(literal("renderPath").then(argument("toggle", toggle()).executes(c -> {
                 CONFIG.client.extra.pathfinder.renderPath = getToggle(c, "toggle");
                 c.getSource().getEmbed()
@@ -842,6 +849,7 @@ public class PathfinderCommand extends Command {
         settingsMap.put("planAheadPrimaryTimeoutMs", String.valueOf(CONFIG.client.extra.pathfinder.planAheadPrimaryTimeoutMs));
         settingsMap.put("planAheadFailureTimeoutMs", String.valueOf(CONFIG.client.extra.pathfinder.planAheadFailureTimeoutMs));
         settingsMap.put("failedPathSearchCooldownMs", String.valueOf(CONFIG.client.extra.pathfinder.failedPathSearchCooldownMs));
+        settingsMap.put("minDistPath", String.valueOf(CONFIG.client.extra.pathfinder.minDistPath));
         settingsMap.put("renderPath", toggleStr(CONFIG.client.extra.pathfinder.renderPath));
         settingsMap.put("renderPathIntervalTicks", String.valueOf(CONFIG.client.extra.pathfinder.pathRenderIntervalTicks));
         settingsMap.put("renderPathDetailed", toggleStr(CONFIG.client.extra.pathfinder.renderPathDetailed));

--- a/src/main/java/com/zenith/feature/pathfinder/calc/AStarPathFinder.java
+++ b/src/main/java/com/zenith/feature/pathfinder/calc/AStarPathFinder.java
@@ -133,7 +133,7 @@ public class AStarPathFinder extends AbstractNodeCostSearch {
                         if (bestHeuristicSoFar[i] - heuristic > minimumImprovement) {
                             bestHeuristicSoFar[i] = heuristic;
                             bestSoFar[i] = neighbor;
-                            if (failing && getDistFromStartSq(neighbor) > MIN_DIST_PATH * MIN_DIST_PATH) {
+                            if (failing && getDistFromStartSq(neighbor) > minDistPathSq) {
                                 failing = false;
                             }
                         }

--- a/src/main/java/com/zenith/feature/pathfinder/calc/AbstractNodeCostSearch.java
+++ b/src/main/java/com/zenith/feature/pathfinder/calc/AbstractNodeCostSearch.java
@@ -43,10 +43,6 @@ public abstract class AbstractNodeCostSearch {
      */
     protected static final double[] COEFFICIENTS = {1.5, 2, 2.5, 3, 4, 5, 10};
 
-    /**
-     * If a path goes less than 5 blocks and doesn't make it to its goal, it's not worth considering.
-     */
-    protected static final double MIN_DIST_PATH = 5;
 
     /**
      * there are floating point errors caused by random combinations of traverse and diagonal over a flat area
@@ -170,7 +166,7 @@ public abstract class AbstractNodeCostSearch {
             if (dist > bestDist) {
                 bestDist = dist;
             }
-            if (dist > MIN_DIST_PATH * MIN_DIST_PATH) { // square the comparison since distFromStartSq is squared
+            if (dist > context.minDistPath * context.minDistPath) { // square the comparison since distFromStartSq is squared
                 return Optional.of(new Path(realStart, startNode, bestSoFar[i], numNodes, goal, context));
             }
         }

--- a/src/main/java/com/zenith/feature/pathfinder/movement/CalculationContext.java
+++ b/src/main/java/com/zenith/feature/pathfinder/movement/CalculationContext.java
@@ -36,6 +36,7 @@ public class CalculationContext {
     public final boolean allowLongFall = CONFIG.client.extra.pathfinder.allowLongFall;
     public final double longFallCostLogMultiplier = CONFIG.client.extra.pathfinder.longFallCostLogMultiplier;
     public final double longFallCostAddCost = CONFIG.client.extra.pathfinder.longFallCostAddCost;
+    public final double minDistPath = CONFIG.client.extra.pathfinder.minDistPath;
 //    public final int maxFallHeightBucket;
     public final double waterWalkSpeed = ActionCosts.WALK_ONE_IN_WATER_COST + ActionCosts.WALK_ONE_BLOCK_COST;
     public final double breakBlockAdditionalCost = CONFIG.client.extra.pathfinder.blockBreakAdditionalCost;

--- a/src/main/java/com/zenith/util/config/Config.java
+++ b/src/main/java/com/zenith/util/config/Config.java
@@ -209,6 +209,7 @@ public final class Config {
                 public double longFallCostLogMultiplier = 50;
                 public double longFallCostAddCost = 100;
                 public int followRadius = 2;
+                public double minDistPath = 5;
                 public int teleportDelayMs = 500;
                 public boolean renderPath = true;
                 public int pathRenderIntervalTicks = 10;


### PR DESCRIPTION
Makes it so much easier to do automation in zenith, goal nears wont try to go to the exact block you want, they will only get within the goal near distance and quit, and goal blocks will always try to build to get to the exact block position instead of going to closest position.