### PR TITLE
kick sessions that stop responding to keep alives

### DIFF
--- a/src/main/java/com/zenith/network/SKeepAliveTask.java
+++ b/src/main/java/com/zenith/network/SKeepAliveTask.java
@@ -5,7 +5,10 @@ import com.zenith.util.config.Config.Client.KeepAliveHandling.KeepAliveMode;
 import org.geysermc.mcprotocollib.protocol.data.ProtocolState;
 import org.geysermc.mcprotocollib.protocol.packet.common.clientbound.ClientboundKeepAlivePacket;
 
+import java.util.concurrent.TimeUnit;
+
 import static com.zenith.Globals.CONFIG;
+import static com.zenith.Globals.SERVER_LOG;
 
 public class SKeepAliveTask implements Runnable {
     private final ServerSession session;
@@ -16,9 +19,24 @@ public class SKeepAliveTask implements Runnable {
 
     @Override
     public void run() {
-        if (!session.isSpectator() && CONFIG.client.keepAliveHandling.keepAliveMode != KeepAliveMode.INDEPENDENT) return;
         var state = session.getPacketProtocol().getOutboundState();
         if (state != ProtocolState.CONFIGURATION && state != ProtocolState.GAME) return;
+        // detect half-open connections that are no longer responding to keep alives
+        // e.g. a controlling player whose internet connection has silently dropped
+        // disconnecting them lets the bot take over and resync teleports before the destination server kicks us
+        if (isKeepAliveTimedOut()) {
+            SERVER_LOG.info("[{}] Disconnecting session that has not responded to keep alives", session.getName());
+            session.disconnect("Timed out");
+            return;
+        }
+        if (!session.isSpectator() && CONFIG.client.keepAliveHandling.keepAliveMode != KeepAliveMode.INDEPENDENT) return;
         this.session.send(new ClientboundKeepAlivePacket(System.currentTimeMillis()));
+    }
+
+    private boolean isKeepAliveTimedOut() {
+        if (!CONFIG.server.extra.timeout.enable) return false;
+        if (!session.isLoggedIn()) return false;
+        var elapsed = System.currentTimeMillis() - session.getLastKeepAliveResponseTime();
+        return elapsed > TimeUnit.SECONDS.toMillis(CONFIG.server.extra.timeout.seconds);
     }
 }

--- a/src/main/java/com/zenith/network/server/ServerSession.java
+++ b/src/main/java/com/zenith/network/server/ServerSession.java
@@ -86,6 +86,9 @@ public class ServerSession extends TcpServerSession {
     protected long ping = 0L;
     protected long lastKeepAliveId = 0L;
     protected long lastKeepAliveTime = 0L;
+    // last time we received a keep alive response from this session
+    // used to detect and disconnect half-open connections, e.g. after a controller's internet outage
+    protected volatile long lastKeepAliveResponseTime = System.currentTimeMillis();
 
     protected boolean whitelistChecked = false;
     protected boolean isPlayer = false;
@@ -290,6 +293,7 @@ public class ServerSession extends TcpServerSession {
 
     public void setLoggedIn() {
         this.isLoggedIn = true;
+        this.lastKeepAliveResponseTime = System.currentTimeMillis();
         if (!Proxy.getInstance().getActiveConnections().contains(this))
             Proxy.getInstance().getActiveConnections().add(this);
     }

--- a/src/main/java/com/zenith/network/server/handler/player/incoming/SPlayerKeepAliveHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/player/incoming/SPlayerKeepAliveHandler.java
@@ -10,6 +10,7 @@ public class SPlayerKeepAliveHandler implements PacketHandler<ServerboundKeepAli
     public static final SPlayerKeepAliveHandler INSTANCE = new SPlayerKeepAliveHandler();
     @Override
     public ServerboundKeepAlivePacket apply(final ServerboundKeepAlivePacket packet, final ServerSession session) {
+        session.setLastKeepAliveResponseTime(System.currentTimeMillis());
         if (packet.getPingId() == session.getLastKeepAliveId()) {
             session.setPing(System.currentTimeMillis() - session.getLastKeepAliveTime());
         }

--- a/src/main/java/com/zenith/network/server/handler/spectator/incoming/KeepAliveSpectatorHandler.java
+++ b/src/main/java/com/zenith/network/server/handler/spectator/incoming/KeepAliveSpectatorHandler.java
@@ -8,6 +8,7 @@ public class KeepAliveSpectatorHandler implements PacketHandler<ServerboundKeepA
     public static final KeepAliveSpectatorHandler INSTANCE = new KeepAliveSpectatorHandler();
     @Override
     public ServerboundKeepAlivePacket apply(final ServerboundKeepAlivePacket packet, final ServerSession session) {
+        session.setLastKeepAliveResponseTime(System.currentTimeMillis());
         if (packet.getPingId() == session.getLastKeepAliveId()) {
             session.setPing(System.currentTimeMillis() - session.getLastKeepAliveTime());
         }


### PR DESCRIPTION
Fixes #303
Half-open controller connections (e.g. after an unstable home internet outage) could remain attached for minutes until a Broken pipe occurred. During that time, teleports were forwarded to the dead controller and never confirmed, leaving the player frozen on the destination server until it kicked the session.
This PR tracks the last keep alive response time on each ServerSession and disconnects sessions that haven't responded within server.extra.timeout.seconds (default 30s), mirroring vanilla server behavior. The check runs in both keepAlive modes and for spectators. After the kick, the bot takes over and resyncs queued teleports well before the destination server's kick threshold, preserving the active session.
Tested by suspending the controlling client's process to simulate a half-open connection: the session is kicked after the timeout, the bot resyncs teleports, and the connection to the destination server survives. Verified normal player and spectator connections are unaffected in both independent and passthrough modes.