### PR TITLE
Suppress forwarding of redundant identical SetHealth packets to controlling clients

### DIFF
--- a/src/main/java/com/zenith/network/client/handler/incoming/SetHealthHandler.java
+++ b/src/main/java/com/zenith/network/client/handler/incoming/SetHealthHandler.java
@@ -10,6 +10,45 @@ import static com.zenith.Globals.*;
 
 public class SetHealthHandler implements ClientEventLoopPacketHandler<ClientboundSetHealthPacket, ClientSession> {
 
+    // Last health/food/saturation forwarded to the controlling player.
+    // Tracked on the client session's netty thread (where apply() runs), so no synchronization needed.
+    private float lastForwardedHealth = Float.NaN;
+    private int lastForwardedFood = Integer.MIN_VALUE;
+    private float lastForwardedSaturation = Float.NaN;
+
+    /**
+     * Some servers (e.g. 2b2t/Folia) send a ClientboundSetHealthPacket every server tick even when
+     * health/food/saturation are unchanged. When a client is controlling the proxy, forwarding every
+     * one of these is harmless for a vanilla client, but prediction-based anticheats such as GrimAC
+     * emit a transaction (ClientboundPing) sandwich for *every* SetHealth they see. At ~20 redundant
+     * health packets per second this doubles the transaction rate and delivers them in bursts, which
+     * corrupts Grim's movement clock and produces constant Simulation setbacks — automated clients
+     * (pathfinder bots) then crawl at half speed or get stuck in a setback loop.
+     *
+     * We still update the cache and fire events for every packet (via applyAsync on the event loop),
+     * but we suppress *forwarding* a health packet to the connected client(s) when it is byte-for-byte
+     * identical to the one we last forwarded. A freshly connected controller receives its current
+     * health through the login cache sync (EntityPlayer#addPackets), so nothing observable changes for
+     * the client; only the redundant per-tick stream is dropped.
+     */
+    @Override
+    public ClientboundSetHealthPacket apply(final ClientboundSetHealthPacket packet, final ClientSession session) {
+        if (packet == null) return null;
+        // Update cache / fire events for every packet, exactly as before.
+        ClientEventLoopPacketHandler.super.apply(packet, session);
+
+        final boolean unchanged = packet.getHealth() == lastForwardedHealth
+            && packet.getFood() == lastForwardedFood
+            && packet.getSaturation() == lastForwardedSaturation;
+
+        lastForwardedHealth = packet.getHealth();
+        lastForwardedFood = packet.getFood();
+        lastForwardedSaturation = packet.getSaturation();
+
+        // Returning null drops the packet from the forward-to-client path in ClientSession#callPacketReceived.
+        return unchanged ? null : packet;
+    }
+
     @Override
     public boolean applyAsync(@NonNull ClientboundSetHealthPacket packet, @NonNull ClientSession session) {
         var player = CACHE.getPlayerCache().getThePlayer();


### PR DESCRIPTION
Fixes #309.

## Problem

Servers like 2b2t send `ClientboundSetHealthPacket` on (nearly) every tick even when health/food/saturation are unchanged. When a client is controlling the proxy on a GrimAC server, these are forwarded 1:1 to the controller. GrimAC emits a transaction (`ClientboundPing`) sandwich for **every** `SetHealth`, so this roughly doubles the transaction rate and delivers transactions in bursts, corrupting Grim's movement clock and producing constant `Simulation`/`Timer` setbacks.

Human players barely notice. Automated/pathfinding clients crawl at a fraction of normal speed or get stuck in a setback loop, since they can't absorb constant sub-block rewinds.

## Change

`SetHealthHandler` still updates the cache and fires `PlayerHealthChangedEvent` for every packet (via `applyAsync`, unchanged), but now overrides `apply` to **only forward a `SetHealth` to connected client(s) when health/food/saturation actually differ from the last one forwarded**. Returning `null` drops the redundant packet from the forward path in `ClientSession#callPacketReceived`.

A freshly connected controller still receives its current health via the login cache sync (`EntityPlayer#addPackets`), so nothing observable changes client-side — only the redundant per-tick stream is dropped. The dedup state lives on the client session's netty thread (where `apply` runs), so no synchronization is needed.

## Testing

Built as a shadowJar and run on two live instances against a 1.21.4 GrimAC backend, same account/route:

| Metric | Before | After |
|---|---|---|
| `SetHealth` to client (idle) | ~22/s | 0/s |
| Grim `Simulation` setbacks | constant | 0 |
| Grim `Timer` setbacks | constant | 0 |
| Automated client throughput | crawl / stuck | normal walking speed |

## Note

I wasn't sure whether the 1:1 forwarding is intentional, so I kept the change minimal and conservative (drop only byte-for-byte-identical consecutive packets). If you'd prefer this gated behind a config flag, happy to adjust. See #309 for the full investigation.
