### PR TITLE
fix: add line-break to align image

### DIFF
--- a/docs/wiki/DigitalOcean-Setup-Guide.md
+++ b/docs/wiki/DigitalOcean-Setup-Guide.md
@@ -5,6 +5,7 @@
 
 ## Select OS and Specs
 Select New York (any datacenter) for lowest ping to 2b2t and best connection reliability
+
 ![Select OS and Specs](./_assets/img/digitalocean-setup/DigitalOcean-Setup-Guide-2.png)
 
 ![OS and Plan Settings](./_assets/img/digitalocean-setup/DigitalOcean-Setup-Guide-3.png)


### PR DESCRIPTION
add a line break to avoid the "Create Droplets" screenshot being at the end of the previous text line, making arranged like the other images on the page.