### PR TITLE
Add BotPrePhysicsTick event for movement-assist plugins

### DIFF
--- a/src/main/java/com/zenith/event/client/BotPrePhysicsTick.java
+++ b/src/main/java/com/zenith/event/client/BotPrePhysicsTick.java
@@ -1,0 +1,9 @@
+package com.zenith.event.client;
+
+// Posted once per bot tick, after the bot has applied the server's latest entity metadata sync
+// (e.g. fall-flying/pose/abilities) for this tick, but before the bot's local physics/movement step runs.
+// Intended for plugins that need to influence tick-local physics-affecting state (e.g. fall-flying) at this
+// exact point, so that client-side prediction stays consistent with what the server confirms a moment later.
+public record BotPrePhysicsTick() {
+    public static final BotPrePhysicsTick INSTANCE = new BotPrePhysicsTick();
+}

--- a/src/main/java/com/zenith/feature/player/Bot.java
+++ b/src/main/java/com/zenith/feature/player/Bot.java
@@ -6,6 +6,7 @@ import com.zenith.Proxy;
 import com.zenith.cache.data.entity.EntityLiving;
 import com.zenith.cache.data.entity.EntityPlayer;
 import com.zenith.cache.data.inventory.Container;
+import com.zenith.event.client.BotPrePhysicsTick;
 import com.zenith.event.client.ClientBotTick;
 import com.zenith.event.client.ClientTickEvent;
 import com.zenith.feature.spectator.SpectatorSync;
@@ -374,6 +375,12 @@ public final class Bot extends ModuleUtils {
         if (movementInput.jumping && !didUpdateFlyState && !wasJumpPressed && !onClimbable() && tryToStartFallFlying()) {
             sendClientPacketAsync(new ServerboundPlayerCommandPacket(CACHE.getPlayerCache().getEntityId(), PlayerState.START_ELYTRA_FLYING));
         }
+        // Extension point for plugins: the server's latest entity metadata for this tick (fall-flying included)
+        // has just been applied above via updateFallFlying(), but the physics/movement step below hasn't run yet.
+        // Plugins implementing their own movement/flight logic can hook this to adjust tick-local physics-affecting
+        // state (e.g. via setFallFlying) at the one point in the tick where doing so stays consistent with what
+        // the server will confirm next, instead of racing the next metadata sync.
+        EVENT_BUS.post(BotPrePhysicsTick.INSTANCE);
         if (isFlying) {
             int verticalDirection = 0;
             if (this.movementInput.isSneaking()) {
@@ -1743,6 +1750,16 @@ public final class Bot extends ModuleUtils {
             return true;
         } else {
             return false;
+        }
+    }
+
+    // Public entry point for plugins (e.g. via a BotPrePhysicsTick subscriber) to set local fall-flying state
+    // directly, without going through tryToStartFallFlying()'s canGlide() gating.
+    public void setFallFlying(boolean value) {
+        if (value) {
+            startFallFlying();
+        } else {
+            stopFallFlying();
         }
     }
 


### PR DESCRIPTION
## Summary

Adds `BotPrePhysicsTick`, a new plugin-facing event posted once per bot tick from `Bot.tick()`, at the exact point after the server's latest entity metadata sync for that tick has been applied (fall-flying included, via `updateFallFlying()`) but before the local physics/movement step runs.

This supports plugins that implement autonomous flight/movement modules — for example, a long-distance elytra autopilot — which need tick-precise control over physics-affecting state like fall-flying. If a plugin sets that state even one tick off from this exact seam, client-side prediction falls out of sync with what the server's own movement validation confirms a moment later, and the server corrects/rubberbands the player. Today the only way to get this ordering right is to fork `Bot.java` directly and splice private logic into the tick method, which means every plugin author who needs it has to maintain their own fork of the whole proxy. This PR replaces that with a proper, general extension point through the existing event-bus API (`EventConsumer.of(...)`), following the same pattern as the existing `ClientBotTick` event.

## Changes

- `src/main/java/com/zenith/event/client/BotPrePhysicsTick.java` (new): a zero-field record event, mirroring `ClientBotTick`'s style/shape.
- `src/main/java/com/zenith/feature/player/Bot.java`: posts `BotPrePhysicsTick.INSTANCE` via `EVENT_BUS.post(...)` at the seam described above (immediately after the existing jump/fall-flying handling block, before the `if (isFlying)` physics block).
- `src/main/java/com/zenith/feature/player/Bot.java`: adds `public void setFallFlying(boolean value)`. There was previously no public way to set this state — `startFallFlying()`/`stopFallFlying()` are package-private — so a plugin subscribed to the new event would otherwise have nothing to call. This is a thin wrapper around the two existing package-private methods; no new logic.

No existing behavior changes when nothing subscribes to the new event — this is purely an additive extension point.

## Test plan

- [x] `./gradlew compileJava` — compiles clean
- [x] `./gradlew shadowJar` — builds successfully
- [ ] Downstream plugin integration test (author-side, not included in this PR)
