### PR TITLE
Add configurable offline UUID modes with prefix support

### DIFF
--- a/src/main/java/com/zenith/command/impl/UnsupportedCommand.java
+++ b/src/main/java/com/zenith/command/impl/UnsupportedCommand.java
@@ -15,6 +15,7 @@ import static com.zenith.command.brigadier.ToggleArgumentType.getToggle;
 import static com.zenith.command.brigadier.ToggleArgumentType.toggle;
 import static com.zenith.discord.DiscordBot.escape;
 import static com.zenith.util.config.Config.Authentication.AccountType.OFFLINE;
+import static com.zenith.util.config.Config.Authentication.OfflineUUIDMode;
 
 public class UnsupportedCommand extends Command {
     @Override
@@ -37,7 +38,9 @@ public class UnsupportedCommand extends Command {
                 "allowOfflinePlayers on/off",
                 "auth type offline",
                 "auth offlineUsername <username>",
-                "auth offlineUUID <uuid>",
+                "auth offlineUUID mode <random/fixed/generated>",
+                "auth offlineUUID prefix <prefix>",
+                "auth offlineUUID set <uuid>",
                 "auth offlineUUID clear"
             )
             .build();
@@ -78,14 +81,30 @@ public class UnsupportedCommand extends Command {
                     Authenticator.INSTANCE.clearAuthCache();
                 })))
                 .then(literal("offlineUUID")
+                    .then(literal("mode").then(argument("mode", enumStrings(OfflineUUIDMode.values())).executes(c -> {
+                        CONFIG.authentication.offlineUUIDMode = OfflineUUIDMode.valueOf(getString(c, "mode").toUpperCase());
+                        c.getSource().getEmbed()
+                            .title("Offline UUID Mode Set");
+                        Proxy.getInstance().cancelLogin();
+                        Authenticator.INSTANCE.clearAuthCache();
+                    })))
+                    .then(literal("prefix").then(argument("prefix", wordWithChars()).executes(c -> {
+                        CONFIG.authentication.offlineUUIDPrefix = getString(c, "prefix");
+                        c.getSource().getEmbed()
+                            .title("Offline UUID Prefix Set");
+                        Proxy.getInstance().cancelLogin();
+                        Authenticator.INSTANCE.clearAuthCache();
+                    })))
                     .then(literal("clear").executes(c -> {
                         CONFIG.authentication.offlineUUID = null;
+                        CONFIG.authentication.offlineUUIDMode = OfflineUUIDMode.RANDOM;
                         c.getSource().getEmbed()
                             .title("Offline UUID Reset");
                     }))
-                    .then(argument("uuid", wordWithChars()).executes(c -> {
+                    .then(literal("set").then(argument("uuid", wordWithChars()).executes(c -> {
                         try {
                             CONFIG.authentication.offlineUUID = UUID.fromString(getString(c, "uuid"));
+                            CONFIG.authentication.offlineUUIDMode = OfflineUUIDMode.FIXED;
                         } catch (Exception e) {
                             c.getSource().getEmbed()
                                 .title("Invalid UUID")
@@ -97,8 +116,9 @@ public class UnsupportedCommand extends Command {
                         Proxy.getInstance().cancelLogin();
                         Authenticator.INSTANCE.clearAuthCache();
                         return OK;
-                    }))
-                ));
+                    })))
+                )
+            );
     }
 
     @Override
@@ -109,9 +129,11 @@ public class UnsupportedCommand extends Command {
             .addField("Allow Offline Players", toggleStr(!CONFIG.server.verifyUsers))
             .addField("Offline Authentication", toggleStr(CONFIG.authentication.accountType == OFFLINE))
             .addField("Offline Username", escape(CONFIG.authentication.username))
+            .addField("Offline UUID Mode", CONFIG.authentication.offlineUUIDMode.name().toLowerCase())
+            .addField("Offline UUID Prefix", escape(CONFIG.authentication.offlineUUIDPrefix))
             .addField("Offline UUID", CONFIG.authentication.offlineUUID != null
                 ? escape(CONFIG.authentication.offlineUUID.toString())
-                : "(random)")
+                : "(auto)")
             .primaryColor();
     }
 }

--- a/src/main/java/com/zenith/network/client/Authenticator.java
+++ b/src/main/java/com/zenith/network/client/Authenticator.java
@@ -59,9 +59,17 @@ public class Authenticator {
     public MinecraftProtocol login()  {
         if (CONFIG.authentication.accountType == OFFLINE) {
             AUTH_LOG.warn("Using offline account: '{}'. Offline accounts will not receive user support.", CONFIG.authentication.username);
+            final UUID offlineUuid = switch (CONFIG.authentication.offlineUUIDMode) {
+                case FIXED -> CONFIG.authentication.offlineUUID != null
+                    ? CONFIG.authentication.offlineUUID
+                    : UUID.randomUUID();
+                case RANDOM -> UUID.randomUUID();
+                case GENERATED -> UUID.nameUUIDFromBytes(
+                    (CONFIG.authentication.offlineUUIDPrefix + CONFIG.authentication.username).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            };
             return createMinecraftProtocol(
                 new MinecraftProfile(
-                    Objects.requireNonNullElseGet(CONFIG.authentication.offlineUUID, UUID::randomUUID),
+                    offlineUuid,
                     CONFIG.authentication.username),
                 null,
                 null);

--- a/src/main/java/com/zenith/util/config/Config.java
+++ b/src/main/java/com/zenith/util/config/Config.java
@@ -41,6 +41,8 @@ public final class Config {
         // updated on successful login
         public String username = "Unknown";
         public @Nullable UUID offlineUUID = null;
+        public OfflineUUIDMode offlineUUIDMode = OfflineUUIDMode.RANDOM;
+        public String offlineUUIDPrefix = "OfflinePlayer:";
         public boolean prio = false;
         public boolean authTokenRefresh = true;
         public int msaLoginAttemptsBeforeCacheWipe = 2;
@@ -55,6 +57,12 @@ public final class Config {
             @SerializedName("device_code_without_device_token") DEVICE_CODE_WITHOUT_DEVICE_TOKEN,
             @SerializedName("prism") PRISM,
             @SerializedName("offline") OFFLINE
+        }
+
+        public enum OfflineUUIDMode {
+            @SerializedName("random") RANDOM,
+            @SerializedName("fixed") FIXED,
+            @SerializedName("generated") GENERATED
         }
     }
 


### PR DESCRIPTION
## Summary

Adds configurable UUID generation modes for offline authentication.

## Changes

- New `OfflineUUIDMode` enum: `RANDOM`, `FIXED`, `GENERATED`
- New config fields: `offlineUUIDMode`, `offlineUUIDPrefix`
- `unsupported auth offlineUUID` gains new subcommands:
  - `mode <random/fixed/generated>`
  - `prefix <prefix>` (default: `OfflinePlayer:`)
  - `set <uuid>` (also switches to FIXED mode)
  - `clear` (reset to RANDOM mode)

## Usage
unsupported auth offlineUUID mode generated unsupported auth offlineUUID prefix OfflinePlayer: unsupported auth offlineUUID mode fixed unsupported auth offlineUUID set 123e4567-e89b-12d3-a456-426614174000

## Notes

- Default mode is `RANDOM` (preserves existing behavior)
- `GENERATED` uses `UUID.nameUUIDFromBytes((prefix + username).getBytes(UTF_8))`
- `FIXED` falls back to random if no UUID configured